### PR TITLE
KNIME-style nodes, ports, and stoplights

### DIFF
--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -14,17 +14,27 @@ export class CustomNodeModel extends NodeModel {
             options: 'red'
         };
 
-        // setup an in and out port
-        this.addPort(
-            new DefaultPortModel({ in: true,
-                name: 'in'
-            })
-        );
-        this.addPort(
-            new DefaultPortModel({ in: false,
-                name: 'out'
-            })
-        );
+        const nIn = options.numPortsIn || 1;
+        const nOut = options.numPortsOut || 1;
+        // setup in and out ports
+        for (let i = 0; i < nIn; ++i) {
+            this.addPort(
+                new DefaultPortModel({
+                    in: true,
+                    type: 'in',
+                    name: `in-${i}`
+                })
+            );
+        }
+        for (let i = 0; i < nOut; ++i) {
+            this.addPort(
+                new DefaultPortModel({
+                    in: false,
+                    type: 'out',
+                    name: `out-${i}`
+                })
+            );
+        }
     }
 
     serialize() {

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -14,8 +14,8 @@ export class CustomNodeModel extends NodeModel {
             options: 'red'
         };
 
-        const nIn = options.numPortsIn || 1;
-        const nOut = options.numPortsOut || 1;
+        const nIn = options.numPortsIn === undefined ? 1 : options.numPortsIn;
+        const nOut = options.numPortsOut === undefined ? 1 : options.numPortsOut;
         // setup in and out ports
         for (let i = 0; i < nIn; ++i) {
             this.addPort(

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { PortWidget } from '@projectstorm/react-diagrams';
+import StatusLight from '../StatusLight';
 import '../../styles/CustomNode.css';
 
 
@@ -31,6 +32,7 @@ export class CustomNodeWidget extends React.Component {
                         { portWidgets["out"] }
                     </div>
                 </div>
+                <StatusLight status="unconfigured" />
             </div>
         );
     }

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -1,19 +1,36 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { PortWidget } from '@projectstorm/react-diagrams';
 import '../../styles/CustomNode.css';
 
 
 export class CustomNodeWidget extends React.Component {
+
     render() {
+        const engine = this.props.engine;
+        const ports = _.values(this.props.node.getPorts());
+        // group ports by type (in/out)
+        const sortedPorts = _.groupBy(ports, p => p.options.type);
+        // create PortWidget array for each type
+        const portWidgets = {};
+        for (let portType in sortedPorts) {
+            portWidgets[portType] = sortedPorts[portType].map(port =>
+                <PortWidget engine={engine} port={port}>
+                        <div className="triangle-port" />
+                </PortWidget>
+            );
+        }
         return (
-            <div className="custom-node" style={{ borderColor: this.props.node.color }}>
-                <PortWidget engine={this.props.engine} port={this.props.node.getPort('in')}>
-                    <div className="circle-port" />
-                </PortWidget>
-                <PortWidget engine={this.props.engine} port={this.props.node.getPort('out')}>
-                    <div className="circle-port" />
-                </PortWidget>
+            <div className="custom-node-wrapper">
                 <div className="custom-node-name">{this.props.node.options.name}</div>
+                <div className="custom-node" style={{ borderColor: this.props.node.color }}>
+                    <div className="port-col port-col-in">
+                        { portWidgets["in"] }
+                    </div>
+                    <div className="port-col port-col-out">
+                        { portWidgets["out"] }
+                    </div>
+                </div>
             </div>
         );
     }

--- a/front-end/src/components/StatusLight.js
+++ b/front-end/src/components/StatusLight.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import * as _ from 'lodash';
+import '../styles/StatusLight.css';
+
+
+function StatusLight(props) {
+    const statuses = {
+        "unconfigured": "red",
+        "configured": "yellow",
+        "complete": "green"
+    };
+    const items = _.keys(statuses).map(s =>
+        <StatusLightItem color={statuses[s]} active={props.status === s} />
+    );
+    return (
+        <div className="StatusLight">
+            { items }
+        </div>
+    )
+}
+
+
+function StatusLightItem(props) {
+    const color = props.active ? props.color : "white";
+    return (
+        <div className="StatusLightItem" style={{backgroundColor: color}} />
+    )
+}
+
+
+export default StatusLight;

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -23,20 +23,27 @@ class Workspace extends React.Component {
                 <Col xs={3} className="node-menu">
                     <div>Drag-and-drop nodes to build a workflow.</div>
                     <hr />
+                    <b>I/O</b>
+                    <ul>
+                        <NodeMenuItem model={{type: 'readCsv'}} name="Read CSV"
+                            numPortsIn={0} color="black" />
+                    </ul>
                     <b>Manipulation</b>
                     <ul>
                         <NodeMenuItem model={{type: 'filter'}} name="Filter Rows"
                             color="red" />
                         <NodeMenuItem model={{type: 'pivot'}} name="Pivot Table"
                             color="blue" />
+                        <NodeMenuItem model={{type: 'multi-in'}} name="Multiple Input Example"
+                            numPortsIn={3} numPortsOut={1}
+                            color="green" />
                     </ul>
                 </Col>
                 <Col xs={9}> 
                     <div style={{position: 'relative', flexGrow: 1}}
                         onDrop={event => {
                             var data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));
-
-                            var node = new CustomNodeModel({name: data.name, color: data.color});
+                            var node = new CustomNodeModel(data);
                             var point = this.engine.getRelativeMousePoint(event);
                             node.setPosition(point);
                             this.model.addNode(node);

--- a/front-end/src/styles/CustomNode.css
+++ b/front-end/src/styles/CustomNode.css
@@ -1,42 +1,42 @@
+.custom-node-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 .custom-node{
-	border: solid 2px gray;
-	border-radius: 5px;
-	width: 50px;
-	height: 50px;
-	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	position: relative;
+    border: solid 2px gray;
+    border-radius: 4px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: space-between;
+    position: relative;
 }
 
-.custom-node-color{
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	width: 20px;
-	height: 20px;
-	transform: translate(-50%, -50%);
-	border-radius: 10px;
+.port-col {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
 }
 
-.custom-node-name{
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, 0%);
-        font-size: 8px;
+.port-col-in {
+    transform: translate(-100%, 0%);
 }
 
-.circle-port{
-	width: 12px;
-	height: 12px;
-	margin: 2px;
-	border-radius: 4px;
-	background: darkgray;
-	cursor: pointer;
+.port-col-out {
+    transform: translate(110%, 0%);
 }
 
-.circle-port:hover{
-	background: mediumpurple;
+.triangle-port {
+    width: 0;
+    height: 0;
+    border-top: 6px solid transparent;
+    border-bottom: 6px solid transparent;
+    border-left: 10px solid #444;
+}
+
+.triangle-port:hover{
+    border-left-color: mediumpurple;
 }
 

--- a/front-end/src/styles/StatusLight.css
+++ b/front-end/src/styles/StatusLight.css
@@ -1,0 +1,16 @@
+.StatusLight {
+    width: 40px;
+    height: 15px;
+    margin-top: 5px;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    background-color: lightgrey;
+}
+
+.StatusLightItem {
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+    background-color: white;
+}


### PR DESCRIPTION
- Modified the custom node model to accept an option for number of input/output ports
- Styled the nodes and ports to look like KNIME
- Added stoplight-style status indicator (hard-coded as "unconfigured" for now)
- Added example nodes with different numbers of ports
<img width="1171" alt="Screen Shot 2020-03-20 at 12 01 46 AM" src="https://user-images.githubusercontent.com/10101166/77134668-69935000-6a3e-11ea-9440-70cb1e1d5191.png">
