### PR TITLE
Add Workflow/Node models; better saving/passing of data in session

### DIFF
--- a/vp/graph.json
+++ b/vp/graph.json
@@ -1,0 +1,1 @@
+{"directed": true, "multigraph": false, "graph": {}, "nodes": [{"id": 1}, {"id": 2}, {"id": 3}], "links": [{"source": 1, "target": 2}, {"source": 2, "target": 3}]}

--- a/vp/graph.json
+++ b/vp/graph.json
@@ -1,1 +1,0 @@
-{"directed": true, "multigraph": false, "graph": {}, "nodes": [{"id": 1}, {"id": 2}, {"id": 3}], "links": [{"source": 1, "target": 2}, {"source": 2, "target": 3}]}

--- a/vp/node/admin.py
+++ b/vp/node/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/vp/node/apps.py
+++ b/vp/node/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class NodeConfig(AppConfig):
+    name = 'node'

--- a/vp/node/models.py
+++ b/vp/node/models.py
@@ -5,16 +5,16 @@
 
 class NodeInterface:
     def __init__(self, node_id, node_type, num_ports_in, num_ports_out):
-        id = node_id
-        type = node_type
-        num_ports_in = num_ports_in
-        num_ports_out = num_ports_out
+        self.node_id = node_id
+        self.node_type = node_type
+        self.num_ports_in = num_ports_in
+        self.num_ports_out = num_ports_out
 
     def execute(self):
         pass
 
     def validate(self):
-        pass
+        return True
 
     def __str__(self):
         return "Test"
@@ -29,7 +29,3 @@ class Node(NodeInterface):
 
     def validate(self):
         return True
-
-    @property
-    def id(self):
-        return self._id

--- a/vp/node/models.py
+++ b/vp/node/models.py
@@ -1,0 +1,35 @@
+""" node/models.py
+
+"""
+
+
+class NodeInterface:
+    def __init__(self, node_id, node_type, num_ports_in, num_ports_out):
+        id = node_id
+        type = node_type
+        num_ports_in = num_ports_in
+        num_ports_out = num_ports_out
+
+    def execute(self):
+        pass
+
+    def validate(self):
+        pass
+
+    def __str__(self):
+        return "Test"
+
+
+class Node(NodeInterface):
+    def __init__(self, node_id, node_type, num_ports_in, num_ports_out):
+        super().__init__(node_id, node_type, num_ports_in, num_ports_out)
+
+    def execute(self):
+        pass
+
+    def validate(self):
+        return True
+
+    @property
+    def id(self):
+        return self._id

--- a/vp/node/tests.py
+++ b/vp/node/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/vp/node/urls.py
+++ b/vp/node/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.node, name='node'),
+]

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -25,7 +25,8 @@ def node(request):
     # Create a new Node with POST info
     # TODO: id is num + 1; rest of info is hard-coded
     num_nodes = workflow.graph.number_of_nodes()
-    new_node = Node(node_id=(num_nodes + 1), node_type="blank", num_ports_in=1, num_ports_out=1)
+    node_id = num_nodes + 1
+    new_node = Node(node_id=node_id, node_type="blank", num_ports_in=1, num_ports_out=1)
 
     # Add Node to graph and re-save workflow to session
     workflow.add_node(new_node)

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -1,0 +1,36 @@
+from django.http import JsonResponse
+import networkx as nx
+import json
+
+from .models import Node
+from workflow.models import Workflow, WorkflowException
+
+workflow = Workflow()
+
+
+def node(request):
+    """ Add new Node to graph
+
+    """
+
+    # Load workflow from session
+    workflow.retrieve_from_session(request)
+
+    # Check if a graph is present
+    if workflow.graph is None:
+        return JsonResponse({
+            'message': 'A workflow has not been created yet.'
+        }, status=404)
+
+    # Create a new Node with POST info
+    # TODO: id is num + 1; rest of info is hard-coded
+    num_nodes = workflow.graph.number_of_nodes()
+    new_node = Node(node_id=(num_nodes + 1), node_type="blank", num_ports_in=1, num_ports_out=1)
+
+    # Add Node to graph and re-save workflow to session
+    workflow.add_node(new_node)
+    workflow.store_in_session(request)
+
+    return JsonResponse({
+        'message': 'Added new node to graph with ID #' + str(num_nodes + 1)
+    })

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -5,8 +5,6 @@ import json
 from .models import Node
 from workflow.models import Workflow, WorkflowException
 
-workflow = Workflow()
-
 
 def node(request):
     """ Add new Node to graph
@@ -14,6 +12,7 @@ def node(request):
     """
 
     # Load workflow from session
+    workflow = Workflow()
     workflow.retrieve_from_session(request)
 
     # Check if a graph is present

--- a/vp/vp/settings.py
+++ b/vp/vp/settings.py
@@ -37,6 +37,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    # Project apps
+    'workflow.apps.WorkflowConfig',
+    'node.apps.NodeConfig',
 ]
 
 MIDDLEWARE = [

--- a/vp/vp/settings.py
+++ b/vp/vp/settings.py
@@ -51,6 +51,9 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # Custom middleware
+    'workflow.middleware.WorkflowMiddleware',
 ]
 
 ROOT_URLCONF = 'vp.urls'

--- a/vp/vp/urls.py
+++ b/vp/vp/urls.py
@@ -21,5 +21,6 @@ from . import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('info/', views.info),
+    path('node/', include('node.urls')),
     path('workflow/', include('workflow.urls')),
 ]

--- a/vp/workflow/middleware.py
+++ b/vp/workflow/middleware.py
@@ -1,0 +1,23 @@
+from .models import Workflow
+
+
+class WorkflowMiddleware:
+    """ Custom middleware
+
+    https://docs.djangoproject.com/en/3.0/topics/http/middleware/
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+        # One-time configuration and initialization.
+        self.workflow = Workflow()
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+        return response

--- a/vp/workflow/models.py
+++ b/vp/workflow/models.py
@@ -1,3 +1,133 @@
-from django.db import models
+import networkx as nx
+import json
 
-# Create your models here.
+class WorkflowInterface:
+    """ Interface for a Workflow object.
+
+    Attributes:
+        _file_path: Location of a workflow file
+        _graph: A NetworkX Directed Graph
+    """
+
+    def __init__(self):
+        self._file_path = None
+        self._graph = None
+
+    def read_json(self):
+        pass
+
+    def retrieve_from_session(self, request):
+        pass
+
+    def store_in_session(self, request):
+        pass
+
+    def write_json(self):
+        pass
+
+    def __str__(self):
+        return "Test"
+
+
+class Workflow(WorkflowInterface):
+    """ A concrete Workflow object.
+
+    """
+    def __init__(self):
+        super().__init__()
+
+    def read_json(self):
+        """ Read a Workflow file saved as JSON into a NetworkX graph
+
+        Returns:
+             NetworkX DiGraph object
+
+        Raises:
+            WorkflowException: on file error or NetworkX parsing
+        """
+        try:
+            with open(self.file_path, 'r') as file:
+                json_data = json.load(file)
+                self.graph = nx.readwrite.json_graph.node_link_graph(json_data)
+
+            return self.graph
+        except OSError as e:
+            raise WorkflowException('read_json', e.strerror)
+        except nx.NetworkXError as e:
+            raise WorkflowException('read_json', e)
+
+    def retrieve_from_session(self, request):
+        """Store Workflow information in the Django session.
+
+        Args:
+            request: The Django request object
+
+        Return:
+            Object containing the graph and file path from the session.
+        """
+        data = request.session['graph']
+        return {
+            'graph': nx.readwrite.json_graph.node_link_graph(data),
+            'file_path': request.session['file_path'],
+        }
+
+    def store_in_session(self, request):
+        """Store Workflow information in the Django session.
+
+        Args:
+            request: The Django request object
+        """
+        request.session['graph'] = nx.readwrite.node_link_data(self.graph)
+        request.session['file_path'] = self.file_path
+        return
+
+    def write_json(self, file_name='example.json'):
+        """ Read a Workflow file saved as JSON into a NetworkX graph
+
+        Args:
+            file_name: Optional argument for file name. Defaults to
+                pre-existing name saved in the Workflow object.
+
+        Returns:
+             NetworkX DiGraph object
+
+        Raises:
+            WorkflowException: on file error or NetworkX parsing
+        """
+        if self.file_path is None:
+            self.file_path = file_name
+
+        try:
+            with open(self.file_path, 'w') as outfile:
+                json.dump(nx.readwrite.json_graph.node_link_data(self.graph), outfile)
+        except OSError as e:
+            raise WorkflowException('write_json', e.strerror)
+        except nx.NetworkXError as e:
+            raise WorkflowException('read_json', e)
+
+        return
+
+    @property
+    def graph(self):
+        return self._graph
+
+    @graph.setter
+    def graph(self, graph):
+        self._graph = graph
+
+    @property
+    def file_path(self):
+        return self._file_path
+
+    @file_path.setter
+    def file_path(self, file_path: str):
+        if file_path[-5:] == '.json':
+            self._file_path = file_path
+        else:
+            raise WorkflowException('load_file', 'File is not JSON.')
+
+
+class WorkflowException(Exception):
+    def __init__(self, action: str, reason: str):
+        self.action = action
+        self.reason = reason

--- a/vp/workflow/models.py
+++ b/vp/workflow/models.py
@@ -1,6 +1,8 @@
 import networkx as nx
 import json
 
+from node.models import Node
+
 class WorkflowInterface:
     """ Interface for a Workflow object.
 
@@ -12,6 +14,9 @@ class WorkflowInterface:
     def __init__(self):
         self._file_path = None
         self._graph = None
+
+    def add_node(self, node: Node):
+        pass
 
     def read_json(self):
         pass
@@ -35,6 +40,10 @@ class Workflow(WorkflowInterface):
     """
     def __init__(self):
         super().__init__()
+
+    def add_node(self, node: Node):
+        if node.validate():
+            self._graph.add_node(node._id)
 
     def read_json(self):
         """ Read a Workflow file saved as JSON into a NetworkX graph
@@ -66,6 +75,10 @@ class Workflow(WorkflowInterface):
             Object containing the graph and file path from the session.
         """
         data = request.session['graph']
+
+        self.graph = nx.readwrite.json_graph.node_link_graph(data)
+        self.file_path = request.session['file_path']
+
         return {
             'graph': nx.readwrite.json_graph.node_link_graph(data),
             'file_path': request.session['file_path'],

--- a/vp/workflow/models.py
+++ b/vp/workflow/models.py
@@ -43,7 +43,7 @@ class Workflow(WorkflowInterface):
 
     def add_node(self, node: Node):
         if node.validate():
-            self._graph.add_node(node._id)
+            self._graph.add_node(node.node_id)
 
     def read_json(self):
         """ Read a Workflow file saved as JSON into a NetworkX graph

--- a/vp/workflow/urls.py
+++ b/vp/workflow/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('new', views.new_workflow, name='new workflow'),
     path('open', views.open_workflow, name='open workflow'),
     path('save', views.save_workflow, name='save'),
 ]

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -10,6 +10,30 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Initialize a Workflow object
 workflow = Workflow()
 
+def new_workflow(request):
+    """ Create a new workflow.
+
+    Initialize a new, empty, NetworkX DiGraph object and store it in
+    the session
+
+    Return:
+        200 - Created new DiGraph
+    """
+    # Create new NetworkX graph
+    DG = nx.DiGraph()
+    json_graph = nx.readwrite.json_graph.node_link_data(DG)
+
+    # Construct response
+    data = {
+        'graph': json_graph,
+        'nodes': DG.number_of_nodes(),
+    }
+
+    # Save to session
+    request.session['graph'] = json_graph
+    return JsonResponse(data)
+
+
 def open_workflow(request):
     """Opens a workflow.
 


### PR DESCRIPTION
Moved a lot of 'view' code into the Workflow model. Can handle read/write to JSON file and retrieve/store information in the Django session.

Also added initial Node app logic to demo adding a new `Node` to the graph. Implemented as GET instead of POST for easier testing.

Try: 
http://localhost:8000/workflow/open — Creates a new DiGraph
http://localhost:8000/workflow/save — saves to 'example.json'
http://localhost:8000/workflow/open?file=example.json — loads into session (probably should happen automatically in previous route)
http://localhost:8000/node — Adds a node to the graph