### PR TITLE
Node configuration and deletion

### DIFF
--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -16,6 +16,9 @@ export class CustomNodeModel extends NodeModel {
             options: 'red'
         };
 
+        // user-defined description of node
+        this._description = null;
+
         const nIn = options.numPortsIn === undefined ? 1 : options.numPortsIn;
         const nOut = options.numPortsOut === undefined ? 1 : options.numPortsOut;
         // setup in and out ports
@@ -50,4 +53,13 @@ export class CustomNodeModel extends NodeModel {
         super.deserialize(ob, engine);
         this.color = ob.color;
     }
+
+    getDescription() {
+        return this._description;
+    }
+
+    setDescription(description) {
+        this._description = description;
+    }
+
 }

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -1,11 +1,30 @@
-import * as React from 'react';
+import React from 'react';
 import * as _ from 'lodash';
 import { PortWidget } from '@projectstorm/react-diagrams';
 import StatusLight from '../StatusLight';
+import NodeConfig from './NodeConfig';
 import '../../styles/CustomNode.css';
 
 
 export class CustomNodeWidget extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {showConfig: false};
+        this.toggleConfig = this.toggleConfig.bind(this);
+        this.handleDelete = this.handleDelete.bind(this);
+    }
+
+    // show/hide node configuration modal
+    toggleConfig() {
+        this.setState({showConfig: !this.state.showConfig});
+    }
+
+    // delete node from diagram model and redraw diagram
+    handleDelete() {
+        this.props.node.remove();
+        this.props.engine.repaintCanvas();
+    }
 
     render() {
         const engine = this.props.engine;
@@ -16,7 +35,7 @@ export class CustomNodeWidget extends React.Component {
         const portWidgets = {};
         for (let portType in sortedPorts) {
             portWidgets[portType] = sortedPorts[portType].map(port =>
-                <PortWidget engine={engine} port={port}>
+                <PortWidget engine={engine} port={port} key={port.getID()}>
                         <div className="triangle-port" />
                 </PortWidget>
             );
@@ -25,6 +44,11 @@ export class CustomNodeWidget extends React.Component {
             <div className="custom-node-wrapper">
                 <div className="custom-node-name">{this.props.node.options.name}</div>
                 <div className="custom-node" style={{ borderColor: this.props.node.color }}>
+                    <div className="custom-node-configure" onClick={this.toggleConfig}>&#x2699;</div>
+                    <NodeConfig node={this.props.node}
+                        show={this.state.showConfig}
+                        toggleShow={this.toggleConfig}
+                        handleDelete={this.handleDelete} />
                     <div className="port-col port-col-in">
                         { portWidgets["in"] }
                     </div>

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -13,6 +13,7 @@ export class CustomNodeWidget extends React.Component {
         this.state = {showConfig: false};
         this.toggleConfig = this.toggleConfig.bind(this);
         this.handleDelete = this.handleDelete.bind(this);
+        this.acceptConfiguration = this.acceptConfiguration.bind(this);
     }
 
     // show/hide node configuration modal
@@ -23,6 +24,11 @@ export class CustomNodeWidget extends React.Component {
     // delete node from diagram model and redraw diagram
     handleDelete() {
         this.props.node.remove();
+        this.props.engine.repaintCanvas();
+    }
+
+    acceptConfiguration(formData) {
+        this.props.node.setDescription(formData.description);
         this.props.engine.repaintCanvas();
     }
 
@@ -48,7 +54,8 @@ export class CustomNodeWidget extends React.Component {
                     <NodeConfig node={this.props.node}
                         show={this.state.showConfig}
                         toggleShow={this.toggleConfig}
-                        handleDelete={this.handleDelete} />
+                        onDelete={this.handleDelete}
+                        onSubmit={this.acceptConfiguration} />
                     <div className="port-col port-col-in">
                         { portWidgets["in"] }
                     </div>
@@ -57,6 +64,7 @@ export class CustomNodeWidget extends React.Component {
                     </div>
                 </div>
                 <StatusLight status="unconfigured" />
+                <div className="custom-node-description">{this.props.node.getDescription()}</div>
             </div>
         );
     }

--- a/front-end/src/components/CustomNode/NodeConfig.js
+++ b/front-end/src/components/CustomNode/NodeConfig.js
@@ -1,28 +1,51 @@
-import React from 'react';
-import { Modal, Button } from 'react-bootstrap';
+import React, { useState } from 'react';
+import { Modal, Button, Form } from 'react-bootstrap';
 import propTypes from 'prop-types';
 
 function NodeConfig(props) {
 
+    //TODO: going to need a much more flexible way of creating
+    // the form fields and handling changes, rather than explicit
+    // state variables and handlers
+
+    const [description, setDescription] = useState();
+    const handleDescriptionChange = (e) => {
+        setDescription(e.target.value);
+    }
+
+
+    // confirm, fire delete callback, close modal
     const handleDelete = () => {
         if (window.confirm("Are you sure you want to delete this node?")) {
-            props.handleDelete();
+            props.onDelete();
             props.toggleShow();
         }
     }
 
+    // fire submit callback, close modal
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        props.onSubmit({description: description});
+        props.toggleShow();
+    }
+
     return (
             <Modal show={props.show} onHide={props.toggleShow} centered>
-                <Modal.Header>
-                    <Modal.Title><b>{props.node.options.name}</b> Configuration</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button variant="success" onClick={props.toggleShow}>Save</Button>
-                    <Button variant="secondary" onClick={props.toggleShow}>Cancel</Button>
-                    <Button variant="danger" onClick={handleDelete}>Delete</Button>
-                </Modal.Footer>
+                <Form onSubmit={handleSubmit}>
+                    <Modal.Header>
+                        <Modal.Title><b>{props.node.options.name}</b> Configuration</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                            <Form.Label>Node Description</Form.Label>
+                            <Form.Control as="textarea" rows="2" value={description}
+                                onChange={handleDescriptionChange} />
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button variant="success" type="submit">Save</Button>
+                        <Button variant="secondary" onClick={props.toggleShow}>Cancel</Button>
+                        <Button variant="danger" onClick={handleDelete}>Delete</Button>
+                    </Modal.Footer>
+                </Form>
             </Modal>
     );
 }
@@ -31,6 +54,9 @@ function NodeConfig(props) {
 NodeConfig.propTypes = {
     show: propTypes.bool,
     toggleShow: propTypes.func,
+    onDelete: propTypes.func,
+    onSubmit: propTypes.func
 }
+
 
 export default NodeConfig;

--- a/front-end/src/components/CustomNode/NodeConfig.js
+++ b/front-end/src/components/CustomNode/NodeConfig.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+import propTypes from 'prop-types';
+
+function NodeConfig(props) {
+
+    const handleDelete = () => {
+        if (window.confirm("Are you sure you want to delete this node?")) {
+            props.handleDelete();
+            props.toggleShow();
+        }
+    }
+
+    return (
+            <Modal show={props.show} onHide={props.toggleShow} centered>
+                <Modal.Header>
+                    <Modal.Title><b>{props.node.options.name}</b> Configuration</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="success" onClick={props.toggleShow}>Save</Button>
+                    <Button variant="secondary" onClick={props.toggleShow}>Cancel</Button>
+                    <Button variant="danger" onClick={handleDelete}>Delete</Button>
+                </Modal.Footer>
+            </Modal>
+    );
+}
+
+
+NodeConfig.propTypes = {
+    show: propTypes.bool,
+    toggleShow: propTypes.func,
+}
+
+export default NodeConfig;

--- a/front-end/src/components/StatusLight.js
+++ b/front-end/src/components/StatusLight.js
@@ -10,7 +10,7 @@ function StatusLight(props) {
         "complete": "green"
     };
     const items = _.keys(statuses).map(s =>
-        <StatusLightItem color={statuses[s]} active={props.status === s} />
+        <StatusLightItem color={statuses[s]} active={props.status === s} key={s} />
     );
     return (
         <div className="StatusLight">

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import * as _ from 'lodash';
 import { Row, Col } from 'react-bootstrap';
 import createEngine, { DiagramModel } from '@projectstorm/react-diagrams';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
 import { CustomLinkFactory } from './CustomLink/CustomLinkFactory';
 import { CustomNodeModel } from './CustomNode/CustomNodeModel';
 import { CustomNodeFactory } from './CustomNode/CustomNodeFactory';
+import * as nodeItems from '../nodeItems.json';
 import '../styles/Workspace.css';
 
 
@@ -20,26 +22,22 @@ class Workspace extends React.Component {
     }
 
     render() {
+        // construct menu from JSON of node types
+        const menu = _.map(nodeItems.default, (items, section) =>
+            <div key={`node-menu-${section}`}>
+                <b>{section}</b>
+                <ul>
+                { _.map(items, item => <NodeMenuItem {...item} />) }
+                </ul>
+            </div>
+        );
+
         return (
             <Row className="Workspace">
                 <Col xs={3} className="node-menu">
                     <div>Drag-and-drop nodes to build a workflow.</div>
                     <hr />
-                    <b>I/O</b>
-                    <ul>
-                        <NodeMenuItem model={{type: 'readCsv'}} name="Read CSV"
-                            numPortsIn={0} color="black" />
-                    </ul>
-                    <b>Manipulation</b>
-                    <ul>
-                        <NodeMenuItem model={{type: 'filter'}} name="Filter Rows"
-                            color="red" />
-                        <NodeMenuItem model={{type: 'pivot'}} name="Pivot Table"
-                            color="blue" />
-                        <NodeMenuItem model={{type: 'multi-in'}} name="Multiple Input Example"
-                            numPortsIn={3} numPortsOut={1}
-                            color="green" />
-                    </ul>
+                    { menu }
                 </Col>
                 <Col xs={9}>
                     <div style={{position: 'relative', flexGrow: 1}}
@@ -49,13 +47,14 @@ class Workspace extends React.Component {
                             var point = this.engine.getRelativeMousePoint(event);
                             node.setPosition(point);
                             this.model.addNode(node);
+                            console.log(node);
                             this.forceUpdate();
                         }}
                     onDragOver={event => {
                             event.preventDefault();
                     }}
                     >
-                    <CanvasWidget className="diagram-canvas" engine={this.engine} />
+                        <CanvasWidget className="diagram-canvas" engine={this.engine} />
                     </div>
                 </Col>
             </Row>

--- a/front-end/src/nodeItems.json
+++ b/front-end/src/nodeItems.json
@@ -1,0 +1,10 @@
+{
+    "I/O": [
+        {"key": "read-csv", "name": "Read CSV", "numPortsIn": 0, "color": "black"}
+    ],
+    "Manipulation": [
+        {"key": "filter", "name": "Filter Rows", "color": "red"},
+        {"key": "pivot", "name": "Pivot Table", "color": "blue"},
+        {"key": "multi-in", "name": "Multi-Input Example", "numPortsIn": 3, "color": "green"}
+    ]
+}

--- a/front-end/src/styles/CustomNode.css
+++ b/front-end/src/styles/CustomNode.css
@@ -40,3 +40,10 @@
     border-left-color: mediumpurple;
 }
 
+.custom-node-configure {
+    cursor: pointer;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}

--- a/front-end/src/styles/CustomNode.css
+++ b/front-end/src/styles/CustomNode.css
@@ -47,3 +47,10 @@
     top: 50%;
     transform: translate(-50%, -50%);
 }
+
+.custom-node-description {
+    margin-top: 5px;
+    text-align: center;
+    max-width: 80px;
+    font-size: 0.5rem;
+}

--- a/front-end/src/styles/Workspace.css
+++ b/front-end/src/styles/Workspace.css
@@ -10,6 +10,10 @@
 }
 .diagram-canvas {
     height: 75vh;
+    background-size: 20px 20px;
+    background-image:
+        linear-gradient(to right, rgba(54, 169, 231, 0.1) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(54, 169, 231, 0.1) 1px, transparent 1px);
 }
 .NodeMenuItem {
     cursor: pointer;


### PR DESCRIPTION
- Add a gear icon to nodes, clicking opens configuration modal
- Allow node deletion via configuration modal
- Display user-defined node description below node (add description from configuration modal)
- Use graph-paper background on workspace
- Create node menu from JSON data so we can replace with API call

![Screen Shot 2020-03-22 at 4 54 34 PM](https://user-images.githubusercontent.com/10101166/77260362-d46ea200-6c5d-11ea-85dd-9b05e9c503a0.png)

![Screen Shot 2020-03-22 at 4 50 59 PM](https://user-images.githubusercontent.com/10101166/77260347-b7d26a00-6c5d-11ea-9ae1-c0078704d21a.png)

 