### PR TITLE
Add 'handle_node' route for create/read/delete of Node

### DIFF
--- a/vp/node/urls.py
+++ b/vp/node/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.node, name='node'),
+    path('<int:node_id>', views.handle_node, name='handle node')
 ]

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -34,3 +34,50 @@ def node(request):
     return JsonResponse({
         'message': 'Added new node to graph with ID #' + str(num_nodes + 1)
     })
+
+
+def handle_node(request, node_id):
+    """ Retrieve a Node from the graph
+
+    Returns:
+        200 - Node was found; data in JSON format
+        404 - Graph or Node does not exist
+        405 - Method not allowed
+        500 - Error processing Node change
+    """
+
+    # Load workflow from session
+    workflow = Workflow()
+    workflow.retrieve_from_session(request)
+
+    # Check if a graph is present
+    if workflow.graph is None:
+        return JsonResponse({
+            'message': 'A workflow has not been created yet.'
+        }, status=404)
+
+    # Check if the graph contains the requested Node
+    if workflow.graph.has_node(node_id) is not True:
+        return JsonResponse({
+            'message': 'The workflow does not contain node id ' + str(node_id)
+        }, status=404)
+
+    # Process request
+    try:
+        # Retrieve node - reads in as Dict
+        # TODO: translate to Node class for more complex methods
+        node = workflow.graph.nodes[node_id]
+
+        if request.method == 'GET':
+            return JsonResponse(node)
+        elif request.method == 'DELETE':
+            workflow.remove_node(node)
+            return JsonResponse({
+                'message': 'Removed node ID #' + str(node['node_id'])
+            })
+        else:
+            return JsonResponse({
+                'message': request.method + ' not yet handled.'
+            }, status=405)
+    except WorkflowException as e:
+        return JsonResponse(e, status=500)


### PR DESCRIPTION
Provides basic framework for most CRUD functionality re: Nodes.

* Create:
    * GET /node
    * Should be a POST, but GET is easier for early testing. (See note below)
* Read: 
    * GET - /node/<node_id>
* Delete
    * DELETE - /node/<node_id>

Testing POST/DELETE doesn't work without some modifications due to Django's CSRF protections. There are many [articles like this one](https://hackernoon.com/automatically-set-csrf-token-in-postman-django-tips-c9ec8eb9eb5b) that describe how to set the CSRF token in Postman, but I was unable to figure it out.

NetworkX graphs store nodes as Dicts. For simplicity, when processing the `handle_node` request, this is not converted/translated to the Node class. As we expand on how information is stored/handled, we may want to update how this is handled. Properties are currently read via the `[]` accessor instead of `.`.