### PR TITLE
Download of Workflow; update Node/Edge functionality

### DIFF
--- a/Postman/Visual Programming.postman_collection.json
+++ b/Postman/Visual Programming.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ad8f6a9f-641f-44a5-810d-39ecadfb5a36",
+		"_postman_id": "166dfed0-fbb1-48e7-a323-945d862575c4",
 		"name": "Visual Programming",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -18,6 +18,94 @@
 					"port": "8000",
 					"path": [
 						"info"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "New workflow",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8000/workflow/new",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"workflow",
+						"new"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Open file (200)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8000/workflow/open?file=example.json",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"workflow",
+						"open"
+					],
+					"query": [
+						{
+							"key": "file",
+							"value": "example.json"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Open file (400-not specified)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8000/workflow/open",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"workflow",
+						"open"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Open file (404-not found)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8000/workflow/open?file=foobar.json",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"workflow",
+						"open"
+					],
+					"query": [
+						{
+							"key": "file",
+							"value": "foobar.json"
+						}
 					]
 				}
 			},

--- a/vp/node/urls.py
+++ b/vp/node/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 urlpatterns = [
     path('', views.node, name='node'),
-    path('<int:node_id>', views.handle_node, name='handle node')
+    path('<str:node_id>', views.handle_node, name='handle node'),
+    path('edge/<str:node_from_id>/<str:node_to_id>', views.edge, name='add edge')
 ]

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -9,6 +9,10 @@ from workflow.models import Workflow, WorkflowException
 def node(request):
     """ Add new Node to graph
 
+    Returns:
+        200 - New Node was added to the graph
+        400 - Node with 'id' already exists in the graph
+        404 - Graph or Node does not exist
     """
 
     # Load workflow from session
@@ -21,18 +25,64 @@ def node(request):
             'message': 'A workflow has not been created yet.'
         }, status=404)
 
-    # Create a new Node with POST info
-    # TODO: id is num + 1; rest of info is hard-coded
-    num_nodes = workflow.graph.number_of_nodes()
-    node_id = num_nodes + 1
-    new_node = Node(node_id=node_id, node_type="blank", num_ports_in=1, num_ports_out=1)
+    # Extract request info for node creation
+    # TODO: info is passed via GET, not POST, for easier testing
+    node_id = request.GET.get('id')
+    node_type = request.GET.get('type')
+    num_in = request.GET.get('numPortsIn')
+    num_out = request.GET.get('numPortsOut')
+
+    if workflow.get_node(node_id) is not None:
+        return JsonResponse({
+            'message': 'A node with id %s already exists in the graph.' % node_id
+        }, status=400)
+
+    # Create a new Node with info
+    # TODO: should perform error-checking or add default values if missing
+    new_node = Node(node_id=node_id,
+                    node_type=node_type,
+                    num_ports_in=num_in,
+                    num_ports_out=num_out)
 
     # Add Node to graph and re-save workflow to session
     workflow.add_node(new_node)
     workflow.store_in_session(request)
 
     return JsonResponse({
-        'message': 'Added new node to graph with ID #' + str(num_nodes + 1)
+        'message': 'Added new node to graph with id: %s' % (node_id)
+    })
+
+
+def edge(request, node_from_id, node_to_id):
+    """ Add new edge to the graph
+
+    """
+    # Load workflow from session
+    workflow = Workflow()
+    workflow.retrieve_from_session(request)
+
+    # Check if a graph is present
+    if workflow.graph is None:
+        return JsonResponse({
+            'message': 'A workflow has not been created yet.'
+        }, status=404)
+
+    # Check if the graph contains the requested Node
+    node_from = workflow.get_node(node_from_id)
+    node_to = workflow.get_node(node_to_id)
+
+    if node_from is None or node_to is None:
+        return JsonResponse({
+            'message': 'The workflow does not contain the node(s) requested.'
+        }, status=404)
+
+    # Add Edge between the Nodes to the graph and re-save workflow to session
+    workflow.add_edge(node_from, node_to)
+    workflow.store_in_session(request)
+
+    return JsonResponse({
+        'message': 'Added new edge to graph from node %s to node %s' %
+                   (node_from.node_id, node_to.node_id)
     })
 
 
@@ -57,19 +107,18 @@ def handle_node(request, node_id):
         }, status=404)
 
     # Check if the graph contains the requested Node
-    if workflow.graph.has_node(node_id) is not True:
+    node = workflow.get_node(node_id)
+
+    if node is None:
         return JsonResponse({
             'message': 'The workflow does not contain node id ' + str(node_id)
         }, status=404)
 
     # Process request
     try:
-        # Retrieve node - reads in as Dict
-        # TODO: translate to Node class for more complex methods
-        node = workflow.graph.nodes[node_id]
-
         if request.method == 'GET':
-            return JsonResponse(node)
+            # Node class is not JSON serializable, so pass in __dict__
+            return JsonResponse(node.__dict__, safe=False)
         elif request.method == 'DELETE':
             workflow.remove_node(node)
             return JsonResponse({

--- a/vp/vp/settings.py
+++ b/vp/vp/settings.py
@@ -88,6 +88,7 @@ DATABASES = {
     # }
 }
 
+MEDIA_ROOT = '/tmp'
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/vp/workflow/models.py
+++ b/vp/workflow/models.py
@@ -1,6 +1,6 @@
 import networkx as nx
 import json
-
+from django.http import HttpResponse
 from django.core.files.storage import FileSystemStorage
 from django.conf import settings
 from node.models import Node
@@ -130,6 +130,12 @@ class Workflow(WorkflowInterface):
         request.session['graph'] = nx.readwrite.node_link_data(self.graph)
         request.session['file_path'] = self.file_path
         return
+
+    def download_json(self):
+        json_str = json.dumps(nx.readwrite.json_graph.node_link_data(self.graph))
+        response = HttpResponse(json_str, content_type='application/json')
+        response['Content-Disposition'] = 'attachment; filename=%s' % self.file_path
+        return response
 
     def write_json(self, file_name='example.json'):
         """ Read a Workflow file saved as JSON into a NetworkX graph

--- a/vp/workflow/models.py
+++ b/vp/workflow/models.py
@@ -72,6 +72,21 @@ class Workflow(WorkflowInterface):
 
         return
 
+    def add_edge(self, node_from: Node, node_to: Node):
+        """ Add a Node object to the graph.
+
+        Args:
+            node_from - The Node the edge originates from
+              node_to - The Node the edge ends at
+
+        TODO:
+            * validate() always returns True; this should perform actual validation
+        """
+        if node_from.validate() and node_to.validate():
+            self._graph.add_edge(node_from.node_id, node_to.node_id)
+
+        return
+
     def remove_node(self, node):
         """ Remove a node from the graph.
 
@@ -174,6 +189,17 @@ class Workflow(WorkflowInterface):
     @graph.setter
     def graph(self, graph):
         self._graph = graph
+
+    def get_node(self, node_id):
+        if self._graph.has_node(node_id) is not True:
+            return None
+
+        json_node = self.graph.nodes[node_id]
+
+        return Node(node_id=node_id,
+                    node_type=json_node['node_type'],
+                    num_ports_in=json_node['num_ports_in'],
+                    num_ports_out=json_node['num_ports_out'])
 
     @property
     def file_path(self):

--- a/vp/workflow/models.py
+++ b/vp/workflow/models.py
@@ -1,7 +1,12 @@
 import networkx as nx
 import json
 
+from django.core.files.storage import FileSystemStorage
+from django.conf import settings
 from node.models import Node
+
+fs = FileSystemStorage(location=settings.MEDIA_ROOT)
+
 
 class WorkflowInterface:
     """ Interface for a Workflow object.
@@ -59,7 +64,7 @@ class Workflow(WorkflowInterface):
 
             for key in node_dict.keys():
                 # Graph node already includes 'id' for lookup
-                if key is 'node_id':
+                if key == 'node_id':
                     continue
 
                 # Add attribute to graph node
@@ -94,8 +99,9 @@ class Workflow(WorkflowInterface):
             OSError: on file error
             NetworkXError: on issue with loading JSON graph data
         """
-
-        with open(self.file_path, 'r') as file:
+        print(fs.location)
+        print(self.file_path)
+        with fs.open(self.file_path, 'r') as file:
             json_data = json.load(file)
             return nx.readwrite.json_graph.node_link_graph(json_data)
 
@@ -146,7 +152,7 @@ class Workflow(WorkflowInterface):
             self.file_path = file_name
 
         try:
-            with open(file_name, 'w') as outfile:
+            with fs.open(file_name, 'w') as outfile:
                 json.dump(nx.readwrite.json_graph.node_link_data(self.graph), outfile)
         except OSError as e:
             raise WorkflowException('write_json', e.strerror)

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -80,7 +80,7 @@ def save_workflow(request):
         request: Django request Object
 
     Returns:
-        JSON response with data.
+        Downloads JSON file representing graph.
     """
     # Check session for existing graph
     if request.session['graph'] is None:
@@ -90,14 +90,10 @@ def save_workflow(request):
     workflow = Workflow()
     try:
         workflow.retrieve_from_session(request)
-        # Write to disk
-        workflow.write_json()
+        return workflow.download_json()
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=404)
 
-    return JsonResponse({
-        'message': 'Saved the graph to ' + workflow.file_path + '!'
-    })
 
 def retrieve_nodes_for_user(request):
     if request.method =='GET':

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -6,10 +6,6 @@ import os
 from django.http import HttpResponse
 
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-
 def new_workflow(request):
     """ Create a new workflow.
 


### PR DESCRIPTION
A few changes in this PR:
1. Better file-handling/storage for the workflow file. Save route now downloads the JSON file to local machine. (Original `write_json()` method is still present, but unused. Now uses the Django file storage API). Not sure if route should do both—write to `/tmp` and download, or just download. This is easily modified.
2. Parameterizes Node creation. Accomplished through a GET request at the moment (instead of POST). Adds error-checking to ensure unique Nodes.
3. Add an edge between `node_from` and `node_to`, given both nodes exist in the graph. Route path can probably be simplified from current `/node/edge/<from>/<to>` and should be moved to a POST request instead of GET.