### PR TITLE
Makes links selectable and deletable

### DIFF
--- a/front-end/src/components/CustomAction/CustomDeleteItemsAction.js
+++ b/front-end/src/components/CustomAction/CustomDeleteItemsAction.js
@@ -1,0 +1,39 @@
+import * as _ from 'lodash'
+import { Action, InputType } from '@projectstorm/react-canvas-core';
+
+export interface CustomDeleteItemsActionOptions {
+	keyCodes?: number[];
+}
+
+/**
+ * Deletes all selected items, but asks for confirmation first
+ */
+export class CustomDeleteItemsAction extends Action {
+	constructor(options: CustomDeleteItemsActionOptions = {}) {
+		options = {
+			keyCodes: [46, 8],
+			...options
+		};
+		super({
+			type: InputType.KEY_DOWN,
+			fire: (event: ActionEvent<React.KeyboardEvent>) => {
+				if (options.keyCodes.indexOf(event.event.keyCode) !== -1) {
+					const selectedEntities = this.engine.getModel().getSelectedEntities();
+					if (selectedEntities.length > 0) {
+						const confirm = window.confirm('Are you sure you want to delete?');
+
+						if (confirm) {
+							_.forEach(selectedEntities, model => {
+								// only delete items which are not locked
+								if (!model.isLocked()) {
+									model.remove();
+								}
+							});
+							this.engine.repaintCanvas();
+						}
+					}
+				}
+			}
+		});
+	}
+}

--- a/front-end/src/components/CustomLink/CustomLinkWidget.js
+++ b/front-end/src/components/CustomLink/CustomLinkWidget.js
@@ -37,6 +37,7 @@ export class CustomLinkWidget extends React.Component<{ model: CustomLinkModel; 
 		this.mounted = false;
 	}
 
+
 	render() {
 		return (
 			<>

--- a/front-end/src/components/CustomLink/CustomLinkWidget.js
+++ b/front-end/src/components/CustomLink/CustomLinkWidget.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-
 export class CustomLinkWidget extends React.Component<{ model: CustomLinkModel; path: string }> {
 
   path: SVGPathElement;

--- a/front-end/src/components/CustomLink/CustomLinkWidget.js
+++ b/front-end/src/components/CustomLink/CustomLinkWidget.js
@@ -37,7 +37,6 @@ export class CustomLinkWidget extends React.Component<{ model: CustomLinkModel; 
 		this.mounted = false;
 	}
 
-
 	render() {
 		return (
 			<>

--- a/front-end/src/components/CustomNode/CustomNodeFactory.js
+++ b/front-end/src/components/CustomNode/CustomNodeFactory.js
@@ -3,7 +3,6 @@ import { CustomNodeModel } from './CustomNodeModel';
 import { CustomNodeWidget } from './CustomNodeWidget';
 import { AbstractReactFactory } from '@projectstorm/react-canvas-core';
 
-
 export class CustomNodeFactory extends AbstractReactFactory {
     constructor() {
         super('custom-node');

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -1,10 +1,6 @@
 import { NodeModel } from '@projectstorm/react-diagrams';
 import { VPPortModel } from '../VPPort/VPPortModel';
 
-
-/**
- * Example of a custom model using pure javascript
- */
 export class CustomNodeModel extends NodeModel {
 
     constructor(options = {}) {

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -1,5 +1,5 @@
 import { NodeModel } from '@projectstorm/react-diagrams';
-import { CustomPortModel } from '../CustomPort/CustomPortModel';
+import { VPPortModel } from '../VPPort/VPPortModel';
 
 
 /**
@@ -24,7 +24,7 @@ export class CustomNodeModel extends NodeModel {
         // setup in and out ports
         for (let i = 0; i < nIn; ++i) {
             this.addPort(
-                new CustomPortModel({
+                new VPPortModel({
                     in: true,
                     type: 'in',
                     name: `in-${i}`
@@ -33,7 +33,7 @@ export class CustomNodeModel extends NodeModel {
         }
         for (let i = 0; i < nOut; ++i) {
             this.addPort(
-                new CustomPortModel({
+                new VPPortModel({
                     in: false,
                     type: 'out',
                     name: `out-${i}`

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -5,7 +5,6 @@ import StatusLight from '../StatusLight';
 import NodeConfig from './NodeConfig';
 import '../../styles/CustomNode.css';
 
-
 export class CustomNodeWidget extends React.Component {
 
     constructor(props) {

--- a/front-end/src/components/CustomPort/CustomPortModel.js
+++ b/front-end/src/components/CustomPort/CustomPortModel.js
@@ -1,7 +1,6 @@
 import { DefaultPortModel } from '@projectstorm/react-diagrams';
 import { CustomLinkModel } from '../CustomLink/CustomLinkModel';
 
-
 export class CustomPortModel extends DefaultPortModel {
       createLinkModel(): CustomLinkModel | null {
           return new CustomLinkModel();

--- a/front-end/src/components/CustomPort/CustomPortModel.js
+++ b/front-end/src/components/CustomPort/CustomPortModel.js
@@ -1,9 +1,11 @@
 import { DefaultPortModel } from '@projectstorm/react-diagrams';
-import { CustomLinkModel } from '../CustomLink/CustomLinkModel';
+// import { CustomLinkModel } from '../CustomLink/CustomLinkModel';
+import { DefaultLinkModel } from '@projectstorm/react-diagrams';
+
 
 export class CustomPortModel extends DefaultPortModel {
-      createLinkModel(): CustomLinkModel | null {
-          return new CustomLinkModel();
+      createLinkModel(): DefaultLinkModel | null {
+          return new DefaultLinkModel();
       }
 
       canLinkToPort(port: PortModel): boolean {

--- a/front-end/src/components/CustomPort/CustomPortModel.js
+++ b/front-end/src/components/CustomPort/CustomPortModel.js
@@ -1,11 +1,10 @@
 import { DefaultPortModel } from '@projectstorm/react-diagrams';
-// import { CustomLinkModel } from '../CustomLink/CustomLinkModel';
-import { DefaultLinkModel } from '@projectstorm/react-diagrams';
+import { CustomLinkModel } from '../CustomLink/CustomLinkModel';
 
 
 export class CustomPortModel extends DefaultPortModel {
-      createLinkModel(): DefaultLinkModel | null {
-          return new DefaultLinkModel();
+      createLinkModel(): CustomLinkModel | null {
+          return new CustomLinkModel();
       }
 
       canLinkToPort(port: PortModel): boolean {

--- a/front-end/src/components/VPLink/VPLinkFactory.js
+++ b/front-end/src/components/VPLink/VPLinkFactory.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { VPLinkModel } from './VPLinkModel';
+import { VPLinkWidget } from './VPLinkWidget';
+import { DefaultLinkFactory } from '@projectstorm/react-diagrams';
+
+export class VPLinkFactory extends DefaultLinkFactory {
+
+    generateModel(): VPLinkModel {
+      return new VPLinkModel();
+    }
+
+    generateReactWidget(event): JSX.Element {
+  		return <VPLinkWidget link={event.model} diagramEngine={this.engine} />;
+  	}
+}

--- a/front-end/src/components/VPLink/VPLinkFactory.js
+++ b/front-end/src/components/VPLink/VPLinkFactory.js
@@ -1,6 +1,4 @@
-import * as React from 'react';
 import { VPLinkModel } from './VPLinkModel';
-import { VPLinkWidget } from './VPLinkWidget';
 import { DefaultLinkFactory } from '@projectstorm/react-diagrams';
 
 export class VPLinkFactory extends DefaultLinkFactory {
@@ -8,8 +6,4 @@ export class VPLinkFactory extends DefaultLinkFactory {
     generateModel(): VPLinkModel {
       return new VPLinkModel();
     }
-
-    generateReactWidget(event): JSX.Element {
-  		return <VPLinkWidget link={event.model} diagramEngine={this.engine} />;
-  	}
 }

--- a/front-end/src/components/VPLink/VPLinkModel.js
+++ b/front-end/src/components/VPLink/VPLinkModel.js
@@ -1,0 +1,23 @@
+import { DefaultLinkModel } from '@projectstorm/react-diagrams';
+
+export class VPLinkModel extends DefaultLinkModel {
+    constructor() {
+        super({
+          type: 'default',
+          width: 5,
+          color: 'orange'
+        });
+    }
+
+    getSVGPath(): string {
+      if (this.isLastPositionDefault()) {
+        return;
+      }
+
+      return super.getSVGPath();
+    }
+
+    isLastPositionDefault() {
+      return this.getLastPoint().getX() === 0 && this.getLastPoint().getY() === 0;
+    }
+}

--- a/front-end/src/components/VPLink/VPLinkWidget.js
+++ b/front-end/src/components/VPLink/VPLinkWidget.js
@@ -1,0 +1,5 @@
+import { DefaultLinkWidget } from '@projectstorm/react-diagrams';
+
+export class VPLinkWidget extends DefaultLinkWidget {
+
+}

--- a/front-end/src/components/VPPort/VPPortModel.js
+++ b/front-end/src/components/VPPort/VPPortModel.js
@@ -1,0 +1,14 @@
+import { DefaultPortModel } from '@projectstorm/react-diagrams';
+import { VPLinkModel } from '../VPLink/VPLinkModel';
+// import { VPLinkModel } from '@projectstorm/react-diagrams';
+
+
+export class VPPortModel extends DefaultPortModel {
+      createLinkModel(): VPLinkModel | null {
+          return new VPLinkModel();
+      }
+
+      canLinkToPort(port: PortModel): boolean {
+        return port instanceof VPPortModel;
+      }
+}

--- a/front-end/src/components/VPPort/VPPortModel.js
+++ b/front-end/src/components/VPPort/VPPortModel.js
@@ -1,7 +1,5 @@
 import { DefaultPortModel } from '@projectstorm/react-diagrams';
 import { VPLinkModel } from '../VPLink/VPLinkModel';
-// import { VPLinkModel } from '@projectstorm/react-diagrams';
-
 
 export class VPPortModel extends DefaultPortModel {
       createLinkModel(): VPLinkModel | null {

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -9,7 +9,6 @@ import { CustomNodeFactory } from './CustomNode/CustomNodeFactory';
 import * as nodeItems from '../nodeItems.json';
 import '../styles/Workspace.css';
 
-
 class Workspace extends React.Component {
 
     constructor(props) {

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { Row, Col } from 'react-bootstrap';
 import createEngine, { DiagramModel } from '@projectstorm/react-diagrams';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
+import { CustomDeleteItemsAction } from './CustomAction/CustomDeleteItemsAction'
 import { CustomLinkFactory } from './CustomLink/CustomLinkFactory';
 import { CustomNodeModel } from './CustomNode/CustomNodeModel';
 import { CustomNodeFactory } from './CustomNode/CustomNodeFactory';
@@ -19,6 +20,7 @@ class Workspace extends React.Component {
         this.engine.getLinkFactories().registerFactory(new CustomLinkFactory());
         this.model = new DiagramModel();
         this.engine.setModel(this.model);
+        this.engine.getActionEventBus().registerAction(new CustomDeleteItemsAction());
     }
 
     render() {

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -3,8 +3,7 @@ import * as _ from 'lodash';
 import { Row, Col } from 'react-bootstrap';
 import createEngine, { DiagramModel } from '@projectstorm/react-diagrams';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
-import { CustomDeleteItemsAction } from './CustomAction/CustomDeleteItemsAction'
-import { CustomLinkFactory } from './CustomLink/CustomLinkFactory';
+import { VPLinkFactory } from './VPLink/VPLinkFactory';
 import { CustomNodeModel } from './CustomNode/CustomNodeModel';
 import { CustomNodeFactory } from './CustomNode/CustomNodeFactory';
 import * as nodeItems from '../nodeItems.json';
@@ -17,10 +16,10 @@ class Workspace extends React.Component {
         super(props);
         this.engine = createEngine();
         this.engine.getNodeFactories().registerFactory(new CustomNodeFactory());
-        this.engine.getLinkFactories().registerFactory(new CustomLinkFactory());
+        this.engine.getLinkFactories().registerFactory(new VPLinkFactory());
         this.model = new DiagramModel();
         this.engine.setModel(this.model);
-        this.engine.getActionEventBus().registerAction(new CustomDeleteItemsAction());
+        this.engine.setMaxNumberPointsPerLink(0);
     }
 
     render() {


### PR DESCRIPTION
This PR addresses:

1. Makes links selectable
2. Makes links deletable

The main fix is given by the line

`      this.engine.setMaxNumberPointsPerLink(0);
`

A `CustomDeleteAction` is added in case we want to have more control about the default react-diagrams action