### PR TITLE
Sample Node subclasses and Node execution

### DIFF
--- a/Postman/Visual Programming.postman_collection.json
+++ b/Postman/Visual Programming.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "166dfed0-fbb1-48e7-a323-945d862575c4",
+		"_postman_id": "94c6f073-1978-444b-99b3-0123cef01056",
 		"name": "Visual Programming",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -18,6 +18,51 @@
 					"port": "8000",
 					"path": [
 						"info"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add node",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8000/node?id=1&type=IO&key=read-csv&numPortsIn=0&numPortsOut=1&file=test.csv",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"node"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "1"
+						},
+						{
+							"key": "type",
+							"value": "IO"
+						},
+						{
+							"key": "key",
+							"value": "read-csv"
+						},
+						{
+							"key": "numPortsIn",
+							"value": "0"
+						},
+						{
+							"key": "numPortsOut",
+							"value": "1"
+						},
+						{
+							"key": "file",
+							"value": "test.csv"
+						}
 					]
 				}
 			},

--- a/Postman/Visual Programming.postman_collection.json
+++ b/Postman/Visual Programming.postman_collection.json
@@ -26,43 +26,53 @@
 		{
 			"name": "Add node",
 			"request": {
-				"method": "GET",
+				"method": "POST",
 				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "node_id",
+							"value": "4",
+							"type": "text"
+						},
+						{
+							"key": "node_type",
+							"value": "IO",
+							"type": "text"
+						},
+						{
+							"key": "node_key",
+							"value": "read-csv",
+							"type": "text"
+						},
+						{
+							"key": "num_in",
+							"value": "0",
+							"type": "text"
+						},
+						{
+							"key": "num_out",
+							"value": "1",
+							"type": "text"
+						},
+						{
+							"key": "file",
+							"value": "test.csv",
+							"type": "text"
+						}
+					]
+				},
 				"url": {
-					"raw": "http://localhost:8000/node?id=1&type=IO&key=read-csv&numPortsIn=0&numPortsOut=1&file=test.csv",
+					"raw": "http://localhost:8000/node/",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
 					"port": "8000",
 					"path": [
-						"node"
-					],
-					"query": [
-						{
-							"key": "id",
-							"value": "1"
-						},
-						{
-							"key": "type",
-							"value": "IO"
-						},
-						{
-							"key": "key",
-							"value": "read-csv"
-						},
-						{
-							"key": "numPortsIn",
-							"value": "0"
-						},
-						{
-							"key": "numPortsOut",
-							"value": "1"
-						},
-						{
-							"key": "file",
-							"value": "test.csv"
-						}
+						"node",
+						""
 					]
 				}
 			},
@@ -165,6 +175,98 @@
 							"key": "file",
 							"value": "foobar.json"
 						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete node",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{environment}}/node/1",
+					"host": [
+						"{{environment}}"
+					],
+					"path": [
+						"node",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get node",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{environment}}/node/1",
+					"host": [
+						"{{environment}}"
+					],
+					"path": [
+						"node",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Execute node",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{environment}}/node/2/execute",
+					"host": [
+						"{{environment}}"
+					],
+					"path": [
+						"node",
+						"2",
+						"execute"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add edge",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{environment}}/node/2/execute",
+					"host": [
+						"{{environment}}"
+					],
+					"path": [
+						"node",
+						"2",
+						"execute"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Save workflow",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{environment}}/workflow/save",
+					"host": [
+						"{{environment}}"
+					],
+					"path": [
+						"workflow",
+						"save"
 					]
 				}
 			},

--- a/Postman/Visual Programming.postman_collection.json
+++ b/Postman/Visual Programming.postman_collection.json
@@ -70,6 +70,20 @@
 		},
 		{
 			"name": "New workflow",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "f36bfdc4-a83f-4f7f-a91e-af704ea64c2e",
+						"exec": [
+							"const response = pm.response.json()",
+							"",
+							"pm.environment.set('graph', response)"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "GET",
 				"header": [],

--- a/pyworkflow/pyworkflow/NodeFactory.py
+++ b/pyworkflow/pyworkflow/NodeFactory.py
@@ -4,31 +4,34 @@ from .node import *
 def node_factory(node_info):
     # Create a new Node with info
     # TODO: should perform error-checking or add default values if missing
-    if node_info['node_type'] == 'IO':
-        new_node = io_node(node_info)
-    elif node_info['node_type'] == 'Manipulation':
-        new_node = manipulation_node(node_info)
+    node_type = node_info.get('node_type')
+    node_key = node_info.get('node_key')
+
+    if node_type == 'IO':
+        new_node = io_node(node_key, node_info)
+    elif node_type == 'Manipulation':
+        new_node = manipulation_node(node_key, node_info)
     else:
         new_node = None
 
     return new_node
 
 
-def io_node(node_info):
-    if node_info['node_key'] == 'read-csv':
+def io_node(node_key, node_info):
+    if node_key == 'read-csv':
         return ReadCsvNode(node_info)
-    elif node_info['node_key'] == 'write-csv':
+    elif node_key == 'write-csv':
         return WriteCsvNode(node_info)
     else:
         return None
 
 
-def manipulation_node(node_info):
-    if node_info['node_key'] == 'filter':
+def manipulation_node(node_key, node_info):
+    if node_key == 'filter':
         return ManipulationNode(node_info)
-    elif node_info['node_key'] == 'pivot':
+    elif node_key == 'pivot':
         return ManipulationNode(node_info)
-    elif node_info['node_key'] == 'multi-in':
+    elif node_key == 'multi-in':
         return ManipulationNode(node_info)
     else:
         return None

--- a/pyworkflow/pyworkflow/NodeFactory.py
+++ b/pyworkflow/pyworkflow/NodeFactory.py
@@ -1,0 +1,34 @@
+from .node import *
+
+
+def node_factory(node_info):
+    # Create a new Node with info
+    # TODO: should perform error-checking or add default values if missing
+    if node_info['node_type'] == 'IO':
+        new_node = io_node(node_info)
+    elif node_info['node_type'] == 'Manipulation':
+        new_node = manipulation_node(node_info)
+    else:
+        new_node = None
+
+    return new_node
+
+
+def io_node(node_info):
+    if node_info['node_key'] == 'read-csv':
+        return ReadCsvNode(node_info)
+    elif node_info['node_key'] == 'write-csv':
+        return WriteCsvNode(node_info)
+    else:
+        return None
+
+
+def manipulation_node(node_info):
+    if node_info['node_key'] == 'filter':
+        return ManipulationNode(node_info)
+    elif node_info['node_key'] == 'pivot':
+        return ManipulationNode(node_info)
+    elif node_info['node_key'] == 'multi-in':
+        return ManipulationNode(node_info)
+    else:
+        return None

--- a/pyworkflow/pyworkflow/__init__.py
+++ b/pyworkflow/pyworkflow/__init__.py
@@ -1,2 +1,3 @@
 from .workflow import Workflow, WorkflowException
-from .node import Node
+from .node import Node, IONode, ManipulationNode, ReadCsvNode, NodeException
+from .NodeFactory import node_factory

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -23,8 +23,62 @@ class Node:
         return "Test"
 
 
+class IONode(Node):
+    """IONodes deal with file-handling in/out of the Workflow.
+
+    Possible types:
+        Read CSV
+        Write CSV
+    """
+    def __init__(self, node_info):
+        super().__init__(node_info)
+        self.file = node_info['file']
 
     def execute(self):
+        pass
+
+    def validate(self):
+        return True
+
+
+class ReadCsvNode(IONode):
+    """ReadCsvNode
+
+    """
+    def execute(self):
+        try:
+            print(self.file)
+            with open(self.file) as file_like:
+                df = pd.read_csv(file_like)
+                self.data = df.to_json()
+        except Exception as e:
+            raise NodeException('read csv', str(e))
+
+    def __str__(self):
+        return "ReadCsvNode"
+
+
+class WriteCsvNode(IONode):
+    """WriteCsvNode
+
+    """
+    def execute(self):
+        try:
+            self.data.to_csv(self.file)
+        except Exception as e:
+            raise NodeException('write csv', str(e))
+
+
+class ManipulationNode(Node):
+    """ManipulationNodes deal with data manipulation.
+
+    Possible types:
+        Pivot
+        Filter
+        Multi-in
+    """
+    def execute(self):
+        print("Executing ManipulationNode")
         pass
 
     def validate(self):

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -7,8 +7,8 @@ class Node:
     """
     def __init__(self, node_info):
         self.node_id = node_info.get('node_id')
-        self.num_in = node_info.get('num_in')
-        self.num_out = node_info.get('num_out')
+        # self.num_in = node_info.get('num_in')
+        # self.num_out = node_info.get('num_out')
         self.node_type = node_info.get('node_type')
         self.node_key = node_info.get('node_key')
         self.data = None
@@ -44,7 +44,21 @@ class IONode(Node):
 class ReadCsvNode(IONode):
     """ReadCsvNode
 
+    Reads a CSV file into a pandas DataFrame.
+
+    Raises:
+         NodeException: any error reading CSV file, converting
+            to DataFrame.
     """
+    num_in = 0
+    num_out = 1
+    color = 'black'
+
+    def __init__(self, node_info):
+        super().__init__(node_info)
+        # self.num_in = 0
+        # self.num_out = 1
+
     def execute(self):
         try:
             # TODO: FileStorage implemented in Django to store in /tmp
@@ -63,7 +77,21 @@ class ReadCsvNode(IONode):
 class WriteCsvNode(IONode):
     """WriteCsvNode
 
+    Writes the current DataFrame to a CSV file.
+
+    Raises:
+        NodeException: any error writing CSV file, converting
+            from DataFrame.
     """
+    num_in = 0
+    num_out = 1
+    color = 'green'
+
+    def __init__(self, node_info):
+        super().__init__(node_info)
+        # self.num_in = 1
+        # self.num_out = 0
+
     def execute(self):
         try:
             self.data.to_csv('/tmp/' + self.file)
@@ -79,6 +107,15 @@ class ManipulationNode(Node):
         Filter
         Multi-in
     """
+    num_in = 1
+    num_out = 1
+    color = 'blue'
+
+    def __init__(self, node_info):
+        super().__init__(node_info)
+        # self.num_in = 1
+        # self.num_out = 1
+
     def execute(self):
         print("Executing ManipulationNode")
         pass

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -47,8 +47,10 @@ class ReadCsvNode(IONode):
     """
     def execute(self):
         try:
-            print(self.file)
-            with open(self.file) as file_like:
+            # TODO: FileStorage implemented in Django to store in /tmp
+            # Right now, /tmp/ is hardcoded, but should be changed as we
+            # further consider file-handling/uploading
+            with open('/tmp/' + self.file) as file_like:
                 df = pd.read_csv(file_like)
                 self.data = df.to_json()
         except Exception as e:
@@ -64,7 +66,7 @@ class WriteCsvNode(IONode):
     """
     def execute(self):
         try:
-            self.data.to_csv(self.file)
+            self.data.to_csv('/tmp/' + self.file)
         except Exception as e:
             raise NodeException('write csv', str(e))
 

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -1,9 +1,17 @@
-class NodeInterface:
-    def __init__(self, node_id, node_type, num_ports_in, num_ports_out):
-        self.node_id = node_id
-        self.node_type = node_type
-        self.num_ports_in = num_ports_in
-        self.num_ports_out = num_ports_out
+import pandas as pd
+
+
+class Node:
+    """Node object
+
+    """
+    def __init__(self, node_info):
+        self.node_id = node_info['node_id']
+        self.num_in = node_info['num_in']
+        self.num_out = node_info['num_out']
+        self.node_type = node_info['node_type']
+        self.node_key = node_info['node_key']
+        self.data = None
 
     def execute(self):
         pass
@@ -15,12 +23,18 @@ class NodeInterface:
         return "Test"
 
 
-class Node(NodeInterface):
-    def __init__(self, node_id, node_type, num_ports_in, num_ports_out):
-        super().__init__(node_id, node_type, num_ports_in, num_ports_out)
 
     def execute(self):
         pass
 
     def validate(self):
         return True
+
+
+class NodeException(Exception):
+    def __init__(self, action: str, reason: str):
+        self.action = action
+        self.reason = reason
+
+    def __str__(self):
+        return self.action + ': ' + self.reason

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -6,11 +6,11 @@ class Node:
 
     """
     def __init__(self, node_info):
-        self.node_id = node_info['node_id']
-        self.num_in = node_info['num_in']
-        self.num_out = node_info['num_out']
-        self.node_type = node_info['node_type']
-        self.node_key = node_info['node_key']
+        self.node_id = node_info.get('node_id')
+        self.num_in = node_info.get('num_in')
+        self.num_out = node_info.get('num_out')
+        self.node_type = node_info.get('node_type')
+        self.node_key = node_info.get('node_key')
         self.data = None
 
     def execute(self):
@@ -32,7 +32,7 @@ class IONode(Node):
     """
     def __init__(self, node_info):
         super().__init__(node_info)
-        self.file = node_info['file']
+        self.file = node_info.get('file')
 
     def execute(self):
         pass

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -93,13 +93,9 @@ class Workflow:
 
         Raises:
             WorkflowException: on issue with removing node from graph
-
-        TODO:
-            * 'node' passed in is a Dict, not custom Node class
-            * Property accessor will need to be changed
         """
         try:
-            self._graph.remove_node(node['node_id'])
+            self._graph.remove_node(node.node_id)
         except nx.NetworkXError:
             raise WorkflowException('remove_node', 'Node does not exist in graph.')
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -2,6 +2,7 @@ import networkx as nx
 import json
 
 from .node import Node
+from .NodeFactory import node_factory
 
 
 class Workflow:
@@ -36,15 +37,16 @@ class Workflow:
             raise WorkflowException('set_file_path', 'File ' + file_path + ' is not JSON.')
 
     def get_node(self, node_id):
+        """Retrieves Node from workflow, if exists
+
+        Return:
+            Node object, if one exists. Otherwise, None.
+        """
         if self._graph.has_node(node_id) is not True:
             return None
 
-        json_node = self.graph.nodes[node_id]
-
-        return Node(node_id=node_id,
-                    node_type=json_node['node_type'],
-                    num_ports_in=json_node['num_ports_in'],
-                    num_ports_out=json_node['num_ports_out'])
+        node_info = self.graph.nodes[node_id]
+        return node_factory(node_info)
 
     def add_node(self, node: Node):
         """ Add a Node object to the graph.
@@ -64,8 +66,8 @@ class Workflow:
 
             for key in node_dict.keys():
                 # Graph node already includes 'id' for lookup
-                if key == 'node_id':
-                    continue
+                # if key == 'node_id':
+                #     continue
                 # Add attribute to graph node
                 self._graph.nodes[node.node_id][key] = node_dict[key]
 

--- a/vp/node/urls.py
+++ b/vp/node/urls.py
@@ -4,5 +4,6 @@ from . import views
 urlpatterns = [
     path('', views.node, name='node'),
     path('<str:node_id>', views.handle_node, name='handle node'),
+    path('<str:node_id>/execute', views.execute_node, name='execute node'),
     path('edge/<str:node_from_id>/<str:node_to_id>', views.edge, name='add edge')
 ]

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -137,7 +137,7 @@ def execute_node(request, node_id):
             'data': node_to_execute.data,
         }, safe=False)
     except NodeException as e:
-        return JsonResponse(e, status=500)
+        return JsonResponse({e.action: e.reason}, status=500)
 
 
 def create_node(request):

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -111,6 +111,35 @@ def handle_node(request, node_id):
             }, status=405)
     except WorkflowException as e:
         return JsonResponse(e, status=500)
+
+
+def execute_node(request, node_id):
+    """Execute the specified node
+
+    """
+    # Load workflow from session
+    workflow = Workflow.from_session(request.session)
+
+    # Check if the graph contains the requested Node
+    node_to_execute = workflow.get_node(node_id)
+
+    if node_to_execute is None:
+        return JsonResponse({
+            'message': 'The workflow does not contain node id ' + str(node_id)
+        }, status=404)
+
+    # Execute node
+    try:
+        node_to_execute.execute()
+        return JsonResponse({
+            'message': 'Node Execution successful!',
+            'node_type': node_to_execute.node_type,
+            'data': node_to_execute.data,
+        }, safe=False)
+    except NodeException as e:
+        return JsonResponse(e, status=500)
+
+
 def create_node(request):
     """Pass all request info to Node Factory.
 


### PR DESCRIPTION
This is my first stab at how our Node subclasses and Node execution might work. I'm still a little new to classes/inheritance in Python, so you might notice some Java-inspired patterns that could be re-written. But, I think this serves as a good foundation we can build on. This should match up with the discussions we've had, but there's definitely still some unanswered questions in this approach (custom nodes??) and room for improvement!

## pyworkflow
* Added a few Node subclasses (`IONode`, `ManipulationNode`, `ReadCsvNode`) to provide customization to the parent `Node` class
* Creation/lookup of Nodes is now handled by a new `node_factory.py` (written as functions, not sure if a class/other implementation would be more appropriate)
    * Node basics should be fine for going to/from the session (stored in the `nx.DiGraph` as `key: value` attributes.). Now works great in conjunction with the factory as the node info can be passed directly to the factory à la `node_factory(self.graph.nodes[node_id])`
    * Didn't fully test pandas DataFrames, but they have [to_json](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html) and [read_json](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html#pandas.read_json) methods, so that should be okay.

## Django views
* Modified the add_node route (to use the node_factory)
* Added an execute_node route

## Testing
* Routes are still all GET-based, instead of POST. While we can skirt around the CSRF issue temporarily, I am having problems with testing via Postman/curl due to our session-based approach. When trying a route that assumes a graph exists, it complains because there is no session to speak of (is my guess at least). So I'm currently doing testing via the browser (hence the GET requests). Any session-based testing tips would be 👍 
* I've attached a sample `workflow.json` and `test.csv` in [vp-test-files.zip](https://github.com/matthew-t-smith/visual-programming/files/4396276/vp-test-files.zip) to use for testing. These should be moved to `/tmp`. You'll find a few comments scattered throughout in the new commits referencing file-handling. tl;dr—workflow is mostly fine, but we should take a look at files for Nodes with input/output.
* To test, you can open (/workflow/open?file=workflow.json) and then execute node (/node/{id}/execute). I added an 'Add node' test to Postman as well. (Again, hasn't succeeded *in* Postman, but has worked for me in the browser).




