### PR TITLE
Use server load/save endpoints from front end

### DIFF
--- a/front-end/src/components/App.js
+++ b/front-end/src/components/App.js
@@ -8,7 +8,7 @@ import Workspace from './Workspace';
 function App() {
 
     return (
-        <Container className="App">
+        <Container fluid={true} className="App">
             <Header />
             <Workspace />
         </Container>

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -159,6 +159,7 @@ function FileUpload(props) {
             const respData = await resp.json();
             props.handleData(respData.react);
         }
+        input.current.value = null;
     };
     const onFileSelect = e => {
         e.preventDefault();

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -35,16 +35,27 @@ class Workspace extends React.Component {
     }
 
     /**
-     * serialize model and download as JSON file
+     * serialize model, POST to server, download response as JSON file
      */
-    save() {
+    async save() {
         const data = JSON.stringify(this.model.serialize());
-        const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(data)
-        const anchor = document.createElement("a")
-        anchor.href = dataStr;
-        anchor.download = "diagram.json";
-        anchor.click();
-        anchor.remove();
+        const resp = await fetch("/workflow/save", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: data
+        });
+        if (resp.status !== 200) {
+            console.log(await resp.json());
+        } else {
+            const downloadData = await resp.json();
+            const dataStr = "data:text/json;charset=utf-8,"
+                + encodeURIComponent(JSON.stringify(downloadData));
+            const anchor = document.createElement("a")
+            anchor.href = dataStr;
+            anchor.download = downloadData.filename || "diagram.json";
+            anchor.click();
+            anchor.remove();
+        }
     }
 
     /**
@@ -83,7 +94,7 @@ class Workspace extends React.Component {
                 <Row className="mb-3">
                     <Col md={12}>
                         <Button size="sm" onClick={this.save}>Save</Button>{' '}
-                        <FileUpload handleFile={this.load}/>{' '}
+                        <FileUpload handleData={this.load}/>{' '}
                         <Button size="sm" onClick={this.clear}>Clear</Button>
                     </Col>
                 </Row>
@@ -135,18 +146,20 @@ function NodeMenuItem(props) {
 
 function FileUpload(props) {
     const input = useRef(null);
-    const readFile = file => {
-        if (!file) return;
-        const fr = new FileReader();
-        fr.addEventListener("load", () => {
-            const data = JSON.parse(fr.result);
-            props.handleFile(data);
+    const uploadFile = async file => {
+        const form = new FormData();
+        form.append("file", file);
+        const resp = await fetch("/workflow/open", {
+            method: "POST",
+            body: form
         });
-        fr.readAsText(file);
+        const respData = await resp.json();
+        props.handleData(respData.react);
     };
     const onFileSelect = e => {
         e.preventDefault();
-        readFile(input.current.files[0]);
+        if (!input.current.files) return;
+        uploadFile(input.current.files[0]);
     };
     return (
         <>

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -153,8 +153,12 @@ function FileUpload(props) {
             method: "POST",
             body: form
         });
-        const respData = await resp.json();
-        props.handleData(respData.react);
+        if (resp.status !== 200) {
+            console.log("Failed to open workflow.");
+        } else {
+            const respData = await resp.json();
+            props.handleData(respData.react);
+        }
     };
     const onFileSelect = e => {
         e.preventDefault();

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -88,12 +88,12 @@ class Workspace extends React.Component {
                     </Col>
                 </Row>
                 <Row className="Workspace">
-                    <Col xs={3} className="node-menu">
+                    <Col xs={2} className="node-menu">
                         <div>Drag-and-drop nodes to build a workflow.</div>
                         <hr />
                         { menu }
                     </Col>
-                    <Col xs={9}>
+                    <Col xs={10}>
                         <div style={{position: 'relative', flexGrow: 1}}
                             onDrop={event => {
                                 var data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -183,6 +183,8 @@ class ViewNode(Node):
         Tabular view
         Graphical view
     """
+    DEFAULT_OPTIONS = {}
+
     def __init__(self, node_info):
         super().__init__(node_info)
         self.url = node_info.get('url')
@@ -204,6 +206,8 @@ class TabularViewNode(ViewNode):
     num_out = 0
     color = 'orange'
 
+    DEFAULT_OPTIONS = {}
+
     def __init__(self, node_info):
         super().__init__(node_info)
 
@@ -223,6 +227,8 @@ class GraphicalViewNode(ViewNode):
     num_in = 1
     num_out = 0
     color = 'purple'
+
+    DEFAULT_OPTIONS = {}
 
     def __init__(self, node_info):
         super().__init__(node_info)

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -138,6 +138,14 @@ class Workflow:
         graph = cls.read_graph_json(file_like)
         return cls(graph)
 
+    @classmethod
+    def from_request(cls, json_data):
+        """
+
+        """
+        graph = nx.readwrite.json_graph.node_link_graph(json_data)
+        return cls(graph)
+
     def to_graph_json(self):
         return nx.readwrite.json_graph.node_link_data(self.graph)
 

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -69,7 +69,14 @@ def open_workflow(request):
         500 - Missing JSON data or
     """
     try:
-        combined_json = json.loads(request.body)
+        # If multi-part form-data, use this
+        # TODO: file is parsed into JSON in memory;
+        #       may want to save to 'fs' for large files
+        uploaded_file = request.FILES['file']
+        combined_json = json.load(uploaded_file)
+
+        # If file is passed in as raw JSON, use this
+        # combined_json = json.loads(request.body)
 
         workflow = Workflow.from_request(combined_json['networkx'])
         react = combined_json['react']

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -35,48 +35,55 @@ def new_workflow(request):
     return JsonResponse(data)
 
 
-@swagger_auto_schema(method='get',
+@swagger_auto_schema(method='post',
                      operation_summary='Open workflow from file.',
-                     operation_description='Loads a JSON file from disk and translates into Workflow object',
+                     operation_description='Loads a JSON file from disk and translates into Workflow object and JSON object of front-end',
                      responses={
                          200: 'Workflow representation in JSON',
                          400: 'No file specified',
                          404: 'File specified not found or not JSON graph'
                      })
-@api_view(['GET'])
+@api_view(['POST'])
 def open_workflow(request):
     """Open a workflow.
 
-    If file is specified in GET request, that file is opened.
+    User uploads a JSON file to the front-end that passes JSON data to be
+    parsed and validated on the back-end.
 
     Args:
-        request: Django request Object
+        request: Django request Object, should follow the pattern:
+            {
+                react: {react-diagrams JSON},
+                networkx: {networkx graph as JSON},
+            }
+
+    Raises:
+        JSONDecodeError: invalid JSON data
+        KeyError: request missing either 'react' or 'networkx' data
+        WorkflowException: error loading JSON into NetworkX DiGraph
 
     Returns:
         200 - JSON response with data.
         400 - No file specified
         404 - File specified not found, or not JSON graph
+        500 - Missing JSON data or
     """
-    # If file included in request, extract it
-    file_path = request.GET.get('file')
-    if file_path is None:
-        return JsonResponse({'message': 'File must be specified.'}, status=400)
-
-    # Read info into Workflow object
     try:
-        with fs.open(file_path) as file_like:
-            workflow = Workflow.from_file(file_like)
-    except OSError as e:
-        return JsonResponse({'message': e.strerror}, status=404)
-    except nx.NetworkXError as e:
-        return JsonResponse({'message': str(e)}, status=404)
+        combined_json = json.loads(request.body)
+
+        workflow = Workflow.from_request(combined_json['networkx'])
+        react = combined_json['react']
+    except KeyError as e:
+        return JsonResponse({'open_workflow': 'Missing data for ' + str(e)}, status=500)
+    except json.JSONDecodeError as e:
+        return JsonResponse({'No React JSON provided': str(e)}, status=500)
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=404)
 
     # Construct response
     data = {
-        'graph': workflow.to_graph_json(),
-        'nodes': workflow.graph.number_of_nodes(),
+        'react': react,
+        'networkx': workflow.to_graph_json(),
     }
 
     # Save Workflow info to session
@@ -104,18 +111,26 @@ def save_workflow(request):
     Returns:
         Downloads JSON file representing graph.
     """
-    # Check session for existing graph
-    if request.session.get('graph') is None:
+    # Retrieve stored workflow
+    workflow = Workflow.from_session(request.session)
+
+    # Check for existing graph
+    if workflow.graph is None:
         return JsonResponse({'message': 'No graph exists.'}, status=404)
 
     # Load session data into Workflow object. If successful, return
     # serialized graph
     try:
-        workflow = Workflow.from_session(request.session)
-        json_str = json.dumps(workflow.to_graph_json())
-        response = HttpResponse(json_str, content_type='application/json')
+        combined_json = json.dumps({
+            'react': json.loads(request.body),
+            'networkx': workflow.to_graph_json(),
+        })
+
+        response = HttpResponse(combined_json, content_type='application/json')
         response['Content-Disposition'] = 'attachment; filename=%s' % workflow.file_path
         return response
+    except json.JSONDecodeError as e:
+        return JsonResponse({'No React JSON provided': str(e)}, status=500)
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=404)
 

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -104,7 +104,8 @@ def open_workflow(request):
                      responses={
                          200: 'Workflow representation in JSON',
                          400: 'No file specified',
-                         404: 'File specified not found or not JSON graph'
+                         404: 'File specified not found or not JSON graph',
+                         500: 'No valid JSON in request body'
                      })
 @api_view(['POST'])
 def save_workflow(request):
@@ -131,6 +132,7 @@ def save_workflow(request):
         combined_json = json.dumps({
             'react': json.loads(request.body),
             'networkx': workflow.to_graph_json(),
+            'filename': workflow.file_path
         })
 
         response = HttpResponse(combined_json, content_type='application/json')


### PR DESCRIPTION
- Load/save on front-end hits endpoints @reelmatt  set up #27
     - Save sends the diagram data, receives the response containing the diagram and backend serializations, and begins a download
     - Load prompts user for file upload, sends to server, receives response, and deserializes/renders diagram
- Workspace occupies full width of screen