### PR TITLE
Integrate node creation and deletion with server

### DIFF
--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -22,9 +22,18 @@ export class CustomNodeWidget extends React.Component {
     }
 
     // delete node from diagram model and redraw diagram
-    handleDelete() {
-        this.props.node.remove();
-        this.props.engine.repaintCanvas();
+    async handleDelete() {
+        const id = this.props.node.options.id;
+        const resp = await fetch(`/node/${id}`, {
+            method: "DELETE"
+        });
+        if (resp.status !== 200) {
+            console.log("Failed to delete node on back end.")
+        } else {
+            this.props.node.remove();
+            this.props.engine.repaintCanvas();
+            console.log(await resp.json());
+        }
     }
 
     acceptConfiguration(formData) {

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -31,7 +31,12 @@ class Workspace extends React.Component {
             const resp = await fetch("/workflow/nodes");
             return resp.json();
         }
+        async function startWorkflow() {
+            const resp = await fetch("/workflow/new");
+            return resp.json();
+        }
         getNodes().then(nodes => this.setState({nodes: nodes}));
+        startWorkflow().then(resp => console.log(resp));
     }
 
     /**

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -83,13 +83,33 @@ class Workspace extends React.Component {
         }
     }
 
+    async handleNodeCreation(event) {
+        const data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));
+        if (!data) return;
+        const node = new CustomNodeModel(data),
+            point = this.engine.getRelativeMousePoint(event);
+        node.setPosition(point);
+        data.node_id = node.options.id;
+        const resp = await fetch("/node/", {
+            method: "POST",
+            body: JSON.stringify(data)
+        });
+        if (resp.status === 200) {
+            this.model.addNode(node);
+            this.forceUpdate();
+            console.log(await resp.json());
+        } else {
+            console.log("Failed to create node on back end.")
+        }
+    }
+
     render() {
         // construct menu from JSON of node types
         const menu = _.map(this.state.nodes, (items, section) =>
             <div key={`node-menu-${section}`}>
                 <b>{section}</b>
                 <ul>
-                { _.map(items, item => <NodeMenuItem {...item} />) }
+                { _.map(items, item => <NodeMenuItem {...item} key={item.node_key} />) }
                 </ul>
             </div>
         );
@@ -111,18 +131,8 @@ class Workspace extends React.Component {
                     </Col>
                     <Col xs={10}>
                         <div style={{position: 'relative', flexGrow: 1}}
-                            onDrop={event => {
-                                var data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));
-                                var node = new CustomNodeModel(data);
-                                var point = this.engine.getRelativeMousePoint(event);
-                                node.setPosition(point);
-                                this.model.addNode(node);
-                                this.forceUpdate();
-                            }}
-                        onDragOver={event => {
-                                event.preventDefault();
-                        }}
-                        >
+                            onDrop={event => this.handleNodeCreation(event)}
+                            onDragOver={event => event.preventDefault() }>
                             <CanvasWidget className="diagram-canvas" engine={this.engine} />
                         </div>
                     </Col>

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -6,10 +6,11 @@ def node_factory(node_info):
     # TODO: should perform error-checking or add default values if missing
     node_type = node_info.get('node_type')
     node_key = node_info.get('node_key')
+    print("node factory sees", node_type, node_key)
 
-    if node_type == 'IO':
+    if node_type == 'IONode':
         new_node = io_node(node_key, node_info)
-    elif node_type == 'Manipulation':
+    elif node_type == 'ManipulationNode':
         new_node = manipulation_node(node_key, node_info)
     else:
         new_node = None
@@ -18,18 +19,18 @@ def node_factory(node_info):
 
 
 def io_node(node_key, node_info):
-    if node_key == 'read-csv':
+    if node_key == 'ReadCsvNode':
         return ReadCsvNode(node_info)
-    elif node_key == 'write-csv':
+    elif node_key == 'WriteCsvNode':
         return WriteCsvNode(node_info)
     else:
         return None
 
 
 def manipulation_node(node_key, node_info):
-    if node_key == 'join':
+    if node_key == 'JoinNode':
         return JoinNode(node_info)
-    elif node_key == 'pivot':
+    elif node_key == 'PivotNode':
         return PivotNode(node_info)
     elif node_key == 'multi-in':
         return ManipulationNode(node_info)

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -6,7 +6,6 @@ def node_factory(node_info):
     # TODO: should perform error-checking or add default values if missing
     node_type = node_info.get('node_type')
     node_key = node_info.get('node_key')
-    print("node factory sees", node_type, node_key)
 
     if node_type == 'IONode':
         new_node = io_node(node_key, node_info)

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -169,8 +169,8 @@ def retrieve_nodes_for_user(request):
             # TODO: check attribute-scope is handled correctly
             child_node = {
                 'name': child.name,
-                'key': child.__name__,
-                'type': parent.__name__,
+                'node_key': child.__name__,
+                'node_type': parent.__name__,
                 'num_in': child.num_in,
                 'num_out': child.num_out,
                 'color': child.color or parent.color,


### PR DESCRIPTION
- Hits new workspace endpoint on page load
- Hits new node endpoint on node drag-and-drop
- Hits delete node endpoint on node deletion
- Fixes the data the server sends to populate node menu

Error handling is minimal, but I try to check most server responses and log non-200s to the console for now. Next up is a banner or something that displays error messages (which the server already sends).