### PR TITLE
Node parameter types, configuration form, and persistence

### DIFF
--- a/front-end/src/components/CustomNode/CustomNodeFactory.js
+++ b/front-end/src/components/CustomNode/CustomNodeFactory.js
@@ -9,7 +9,7 @@ export class CustomNodeFactory extends AbstractReactFactory {
     }
 
     generateModel(event) {
-        return new CustomNodeModel(event.initialConfig.options);
+        return new CustomNodeModel(event.initialConfig.options, event.initialConfig.config);
     }
 
     generateReactWidget(event) {

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -3,14 +3,13 @@ import { VPPortModel } from '../VPPort/VPPortModel';
 
 export class CustomNodeModel extends NodeModel {
 
-    constructor(options = {}) {
+    constructor(options = {}, config = {}) {
         super({
             ...options,
             type: 'custom-node'
         });
-
-        // user-defined description of node
-        this._description = null;
+        this.config = config;
+        this.configParams = options.option_types;
 
         const nIn = options.num_in === undefined ? 1 : options.num_in;
         const nOut = options.num_out === undefined ? 1 : options.num_out;
@@ -39,19 +38,11 @@ export class CustomNodeModel extends NodeModel {
         return {
             ...super.serialize(),
             options: this.options,
+            config: this.config
         }
     }
 
     deserialize(ob, engine) {
         super.deserialize(ob, engine);
     }
-
-    getDescription() {
-        return this._description;
-    }
-
-    setDescription(description) {
-        this._description = description;
-    }
-
 }

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -8,6 +8,7 @@ export class CustomNodeModel extends NodeModel {
             ...options,
             type: 'custom-node'
         });
+        this.options.node_id = this.options.id;
         this.config = config;
         this.configParams = options.option_types;
 

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -36,10 +36,22 @@ export class CustomNodeWidget extends React.Component {
         }
     }
 
-    acceptConfiguration(formData) {
+    async acceptConfiguration(formData) {
         this.props.node.config = formData;
-        this.forceUpdate();
-        this.props.engine.repaintCanvas();
+        console.log(formData);
+        const node = this.props.node;
+        const payload = {...node.options, options: node.config};
+        const resp = await fetch(`/node/${node.options.id}`, {
+            method: "POST",
+            body: JSON.stringify(payload)
+        });
+        if (resp.status !== 200) {
+            console.log("Failed to update node on back end.")
+        } else {
+            console.log(await resp.json());
+            this.forceUpdate();
+            this.props.engine.repaintCanvas();
+        }
     }
 
     render() {

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -37,7 +37,8 @@ export class CustomNodeWidget extends React.Component {
     }
 
     acceptConfiguration(formData) {
-        this.props.node.setDescription(formData.description);
+        this.props.node.config = formData;
+        this.forceUpdate();
         this.props.engine.repaintCanvas();
     }
 
@@ -73,7 +74,7 @@ export class CustomNodeWidget extends React.Component {
                     </div>
                 </div>
                 <StatusLight status="unconfigured" />
-                <div className="custom-node-description">{this.props.node.getDescription()}</div>
+                <div className="custom-node-description">{this.props.node.config.description}</div>
             </div>
         );
     }

--- a/front-end/src/components/CustomNode/NodeConfig.js
+++ b/front-end/src/components/CustomNode/NodeConfig.js
@@ -13,14 +13,17 @@ function NodeConfig(props) {
             props.onDelete();
             props.toggleShow();
         }
-    }
+    };
 
-    // fire submit callback, close modal
+    // collect config data, fire submit callback, close modal
     const handleSubmit = (e) => {
         e.preventDefault();
-        props.onSubmit({description: description});
+        const fd = new FormData(form.current);
+        const data = {};
+        fd.forEach((value, key) => {data[key] = value;});
+        props.onSubmit(data);
         props.toggleShow();
-    }
+    };
 
     return (
             <Modal show={props.show} onHide={props.toggleShow} centered>

--- a/front-end/src/components/CustomNode/NodeConfig.js
+++ b/front-end/src/components/CustomNode/NodeConfig.js
@@ -1,18 +1,11 @@
-import React, { useState } from 'react';
+import React, { useRef } from 'react';
 import { Modal, Button, Form } from 'react-bootstrap';
 import propTypes from 'prop-types';
+import * as _ from 'lodash';
 
 function NodeConfig(props) {
 
-    //TODO: going to need a much more flexible way of creating
-    // the form fields and handling changes, rather than explicit
-    // state variables and handlers
-
-    const [description, setDescription] = useState();
-    const handleDescriptionChange = (e) => {
-        setDescription(e.target.value);
-    }
-
+    const form = useRef();
 
     // confirm, fire delete callback, close modal
     const handleDelete = () => {
@@ -31,14 +24,21 @@ function NodeConfig(props) {
 
     return (
             <Modal show={props.show} onHide={props.toggleShow} centered>
-                <Form onSubmit={handleSubmit}>
+                <Form onSubmit={handleSubmit} ref={form}>
                     <Modal.Header>
                         <Modal.Title><b>{props.node.options.name}</b> Configuration</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>
+                        { _.map(props.node.configParams, (info, key) =>
+                            <OptionInput key={key} {...info} keyName={key}
+                                value={props.node.config[key]} />
+                        )}
+                        <Form.Group>
                             <Form.Label>Node Description</Form.Label>
-                            <Form.Control as="textarea" rows="2" value={description}
-                                onChange={handleDescriptionChange} />
+                            <Form.Control as="textarea" rows="2"
+                                name="description"
+                                defaultValue={props.node.config.description} />
+                        </Form.Group>
                     </Modal.Body>
                     <Modal.Footer>
                         <Button variant="success" type="submit">Save</Button>
@@ -58,5 +58,24 @@ NodeConfig.propTypes = {
     onSubmit: propTypes.func
 }
 
+
+function OptionInput(props) {
+    let inputComp;
+    if (props.type === "file") {
+        inputComp = <input type="file" name={props.keyName} />;
+    } else if (props.type === "string") {
+        inputComp = <Form.Control type="text" name={props.keyName}
+                        defaultValue={props.value} />;
+    } else {
+        return (<></>)
+    }
+    return (
+        <Form.Group>
+                <Form.Label>{props.name}</Form.Label>
+                <div style={{fontSize: '0.7rem'}}>{props.desc}</div>
+                { inputComp }
+        </Form.Group>
+    )
+}
 
 export default NodeConfig;

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -94,7 +94,7 @@ class Workspace extends React.Component {
         data.node_id = node.options.id;
         const resp = await fetch("/node/", {
             method: "POST",
-            body: JSON.stringify(data)
+            body: JSON.stringify({node_info: data, config: config})
         });
         if (resp.status === 200) {
             this.model.addNode(node);

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -89,10 +89,10 @@ class Workspace extends React.Component {
         const node = new CustomNodeModel(data.nodeInfo, data.config),
             point = this.engine.getRelativeMousePoint(event);
         node.setPosition(point);
-        data.node_id = node.options.id;
+        const payload = {...node.options, options: node.config};
         const resp = await fetch("/node/", {
             method: "POST",
-            body: JSON.stringify({node_info: data, config: config})
+            body: JSON.stringify(payload)
         });
         if (resp.status === 200) {
             this.model.addNode(node);

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -86,7 +86,9 @@ class Workspace extends React.Component {
     async handleNodeCreation(event) {
         const data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));
         if (!data) return;
-        const node = new CustomNodeModel(data),
+        const config = data.options;
+        delete data.options;
+        const node = new CustomNodeModel(data, config),
             point = this.engine.getRelativeMousePoint(event);
         node.setPosition(point);
         data.node_id = node.options.id;

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -86,9 +86,7 @@ class Workspace extends React.Component {
     async handleNodeCreation(event) {
         const data = JSON.parse(event.dataTransfer.getData('storm-diagram-node'));
         if (!data) return;
-        const config = data.options;
-        delete data.options;
-        const node = new CustomNodeModel(data, config),
+        const node = new CustomNodeModel(data.nodeInfo, data.config),
             point = this.engine.getRelativeMousePoint(event);
         node.setPosition(point);
         data.node_id = node.options.id;
@@ -111,7 +109,13 @@ class Workspace extends React.Component {
             <div key={`node-menu-${section}`}>
                 <b>{section}</b>
                 <ul>
-                { _.map(items, item => <NodeMenuItem {...item} key={item.node_key} />) }
+                { _.map(items, item => {
+                    const config = item.options;
+                    delete item.options;
+                    return (
+                        <NodeMenuItem key={item.node_key} nodeInfo={item} config={config} />
+                    )}
+                )}
                 </ul>
             </div>
         );
@@ -154,8 +158,8 @@ function NodeMenuItem(props) {
                     'storm-diagram-node',
                     JSON.stringify(props));
             }}
-            style={{ color: props.color }}>
-            {props.name}
+            style={{ color: props.nodeInfo.color }}>
+            {props.nodeInfo.name}
         </li>
     )
 }

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -71,20 +71,23 @@ class ReadCsvNode(IONode):
         'sep': ',',
         'header': 'infer',
     }
+
     OPTION_TYPES = {
         'filepath_or_buffer': {
             "type": "file",
             "name": "File",
             "desc": "File to read"
-            },
-        'sep': {"type": "string",
-                "name": "Delimiter",
-                "desc": "column delimiter, default ','"
-            },
-        'header': {"type": "string",
-                   "name": "Column Name Row",
-                   "desc": "Row number with column names (0-indexed) or 'infer'"
-            }
+        },
+        'sep': {
+            "type": "string",
+            "name": "Delimiter",
+            "desc": "column delimiter, default ','"
+        },
+        'header': {
+            "type": "string",
+            "name": "Column Name Row",
+            "desc": "Row number with column names (0-indexed) or 'infer'"
+        }
     }
 
     def __init__(self, node_info, options=dict()):

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -71,6 +71,21 @@ class ReadCsvNode(IONode):
         'sep': ',',
         'header': 'infer',
     }
+    OPTION_TYPES = {
+        'filepath_or_buffer': {
+            "type": "file",
+            "name": "File",
+            "desc": "File to read"
+            },
+        'sep': {"type": "string",
+                "name": "Delimiter",
+                "desc": "column delimiter, default ','"
+            },
+        'header': {"type": "string",
+                   "name": "Column Name Row",
+                   "desc": "Row number with column names (0-indexed) or 'infer'"
+            }
+    }
 
     def __init__(self, node_info, options=dict()):
         super().__init__(node_info, {**self.DEFAULT_OPTIONS, **options})

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -1,39 +1,37 @@
 from .node import *
 
 
-def node_factory(payload):
+def node_factory(node_info):
     # Create a new Node with info
     # TODO: should perform error-checking or add default values if missing
-    node_info = payload["node_info"]
-    node_config = payload["config"]
     node_type = node_info.get('node_type')
     node_key = node_info.get('node_key')
 
     if node_type == 'IONode':
-        new_node = io_node(node_key, node_info, node_config)
+        new_node = io_node(node_key, node_info)
     elif node_type == 'ManipulationNode':
-        new_node = manipulation_node(node_key, node_info, node_config)
+        new_node = manipulation_node(node_key, node_info)
     else:
         new_node = None
 
     return new_node
 
 
-def io_node(node_key, node_info, node_config):
+def io_node(node_key, node_info):
     if node_key == 'ReadCsvNode':
-        return ReadCsvNode(node_info, node_config)
+        return ReadCsvNode(node_info)
     elif node_key == 'WriteCsvNode':
-        return WriteCsvNode(node_info, node_config)
+        return WriteCsvNode(node_info)
     else:
         return None
 
 
-def manipulation_node(node_key, node_info, node_config):
+def manipulation_node(node_key, node_info):
     if node_key == 'JoinNode':
-        return JoinNode(node_info, node_config)
+        return JoinNode(node_info)
     elif node_key == 'PivotNode':
-        return PivotNode(node_info, node_config)
+        return PivotNode(node_info)
     elif node_key == 'multi-in':
-        return ManipulationNode(node_info, node_config)
+        return ManipulationNode(node_info)
     else:
         return None

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -1,37 +1,39 @@
 from .node import *
 
 
-def node_factory(node_info):
+def node_factory(payload):
     # Create a new Node with info
     # TODO: should perform error-checking or add default values if missing
+    node_info = payload["node_info"]
+    node_config = payload["config"]
     node_type = node_info.get('node_type')
     node_key = node_info.get('node_key')
 
     if node_type == 'IONode':
-        new_node = io_node(node_key, node_info)
+        new_node = io_node(node_key, node_info, node_config)
     elif node_type == 'ManipulationNode':
-        new_node = manipulation_node(node_key, node_info)
+        new_node = manipulation_node(node_key, node_info, node_config)
     else:
         new_node = None
 
     return new_node
 
 
-def io_node(node_key, node_info):
+def io_node(node_key, node_info, node_config):
     if node_key == 'ReadCsvNode':
-        return ReadCsvNode(node_info)
+        return ReadCsvNode(node_info, node_config)
     elif node_key == 'WriteCsvNode':
-        return WriteCsvNode(node_info)
+        return WriteCsvNode(node_info, node_config)
     else:
         return None
 
 
-def manipulation_node(node_key, node_info):
+def manipulation_node(node_key, node_info, node_config):
     if node_key == 'JoinNode':
-        return JoinNode(node_info)
+        return JoinNode(node_info, node_config)
     elif node_key == 'PivotNode':
-        return PivotNode(node_info)
+        return PivotNode(node_info, node_config)
     elif node_key == 'multi-in':
-        return ManipulationNode(node_info)
+        return ManipulationNode(node_info, node_config)
     else:
         return None

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -238,11 +238,11 @@ def retrieve_data(request, node_id):
 
     return JsonResponse(data, safe=False, status=200)
 
-def create_node(node_info):
+def create_node(payload):
     """Pass all request info to Node Factory.
 
     """
-    json_data = json.loads(node_info)
+    json_data = json.loads(payload)
 
     try:
         return node_factory(json_data)

--- a/vp/vp/views.py
+++ b/vp/vp/views.py
@@ -54,6 +54,7 @@ def retrieve_nodes_for_user(request):
                 'color': child.color or parent.color,
                 'doc': child.__doc__,
                 'options': {**parent.DEFAULT_OPTIONS, **child.DEFAULT_OPTIONS},
+                'option_types': getattr(child, "OPTION_TYPES", dict()),
             }
 
             data[parent.__name__].append(child_node)

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -29,6 +29,7 @@ def new_workflow(request):
     """
     # Create new Workflow
     request.pyworkflow = Workflow()
+    request.session.update(request.pyworkflow.to_session_dict())
 
     return JsonResponse(request.pyworkflow.to_graph_json())
 
@@ -77,6 +78,7 @@ def open_workflow(request):
         # combined_json = json.loads(request.body)
 
         request.pyworkflow = Workflow.from_request(combined_json['networkx'])
+        request.session.update(request.pyworkflow.to_session_dict())
         react = combined_json['react']
     except KeyError as e:
         return JsonResponse({'open_workflow': 'Missing data for ' + str(e)}, status=500)


### PR DESCRIPTION
- Fixes bug where session graph was not getting updated by /new and /open endpoints (because they are exempt from the middleware)
- Defines `OPTION_TYPES` attr on `ReadCsvNode`, and sends to front-end in node list
- Renders node configuration form based on these fields and types
- Adjusts the JS `CustomNodeModel` to distinguish between node info (e.g. name, color) and config options (filename, delimiter)
- Integrates node configuration with update node endpoint

~Although options set on the front-end via the configuration form are maintained in the JS state, I haven't hooked it up to the endpoint that updates nodes on the server. If I get it done before this PR is merged, I think it fits in here well.~