### PR TITLE
Node execution with predecessor data

### DIFF
--- a/Postman/Visual Programming-Nodes.postman_collection.json
+++ b/Postman/Visual Programming-Nodes.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f166b8cb-8fb3-4c12-8709-e2b1ba28d53d",
+		"_postman_id": "2abea1fb-028c-4b16-8bd1-4c9898e0f383",
 		"name": "Visual Programming-Nodes",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -24,13 +24,71 @@
 			"response": []
 		},
 		{
-			"name": "Add node",
+			"name": "Add ReadCsvNode",
 			"request": {
 				"method": "POST",
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"name\": null,\n    \"node_id\": \"4\",\n    \"node_type\": \"IONode\",\n    \"node_key\": \"ReadCsvNode\"\n    \"options\": {\n    \t\"filepath_or_buffer\": \"/tmp/test.csv\"\n    }\n}",
+					"raw": "{\n    \"name\": null,\n    \"node_id\": \"1\",\n    \"node_type\": \"IONode\",\n    \"node_key\": \"ReadCsvNode\",\n    \"options\": {\n    \t\"filepath_or_buffer\": \"/tmp/join1.csv\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8000/node/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"node",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add JoinNode",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"name\": null,\n    \"node_id\": \"3\",\n    \"node_type\": \"ManipulationNode\",\n    \"node_key\": \"JoinNode\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8000/node/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"node",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add WriteCsvNode",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"name\": null,\n    \"node_id\": \"4\",\n    \"node_type\": \"IONode\",\n    \"node_key\": \"WriteCsvNode\",\n    \"options\": {\n    \t\"path_or_buf\": \"/tmp/join_test_output.csv\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -120,6 +178,43 @@
 			"name": "Add edge",
 			"request": {
 				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "node_from_id",
+							"value": "1",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "node_to_id",
+							"value": "2",
+							"type": "text",
+							"disabled": true
+						}
+					]
+				},
+				"url": {
+					"raw": "{{environment}}/node/edge/1/2",
+					"host": [
+						"{{environment}}"
+					],
+					"path": [
+						"node",
+						"edge",
+						"1",
+						"2"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Remove edge",
+			"request": {
+				"method": "DELETE",
 				"header": [],
 				"body": {
 					"mode": "formdata",

--- a/pyworkflow/pyworkflow/__init__.py
+++ b/pyworkflow/pyworkflow/__init__.py
@@ -1,3 +1,3 @@
 from .workflow import Workflow, WorkflowException
-from .node import Node, IONode, ManipulationNode, ReadCsvNode, NodeException
+from .node import Node, IONode, ManipulationNode, ReadCsvNode, WriteCsvNode, JoinNode, NodeException
 from .node_factory import node_factory

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+# from .workflow import Workflow
+
 
 class Node:
     """Node object
@@ -10,7 +12,7 @@ class Node:
         self.node_id = node_info.get('node_id')
         self.node_type = node_info.get('node_type')
         self.node_key = node_info.get('node_key')
-        self.data = None
+        self.data = node_info.get('data')
 
         # Execution options are passed up from children
         self.options = options or dict()
@@ -19,7 +21,7 @@ class Node:
         if node_info.get("options"):
             self.options.update(node_info["options"])
 
-    def execute(self):
+    def execute(self, predecessor_data):
         pass
 
     def validate(self):
@@ -45,7 +47,7 @@ class IONode(Node):
     def __init__(self, node_info, options=dict()):
         super().__init__(node_info, {**IONode.DEFAULT_OPTIONS, **options})
 
-    def execute(self):
+    def execute(self, predecessor_data):
         pass
 
     def validate(self):
@@ -93,13 +95,13 @@ class ReadCsvNode(IONode):
     def __init__(self, node_info, options=dict()):
         super().__init__(node_info, {**self.DEFAULT_OPTIONS, **options})
 
-    def execute(self):
+    def execute(self, predecessor_data):
         try:
             # TODO: FileStorage implemented in Django to store in /tmp
             #       Better filename/path handling should be implemented.
 
             df = pd.read_csv(**self.options)
-            self.data = df.to_json()
+            return df.to_json()
         except Exception as e:
             raise NodeException('read csv', str(e))
 
@@ -128,15 +130,21 @@ class WriteCsvNode(IONode):
     def __init__(self, node_info, options=dict()):
         super().__init__(node_info, {**self.DEFAULT_OPTIONS, **options})
 
-    def execute(self):
+    def execute(self, predecessor_data):
         try:
-            # TODO: DataFrame would be stored from prior Node execution
-            # Create empty DataFrame
-            self.data = pd.DataFrame().to_json()
+            # Write CSV needs exactly 1 input DataFrame
+            if len(predecessor_data) != self.num_in:
+                raise NodeException(
+                    'execute',
+                    'WriteCsv needs %d inputs. %d were provided' % (self.num_in, len(predecessor_data))
+                )
 
-            # Read in empty DataFrame to export
-            df = pd.read_json(self.data)
+            # Convert JSON data to DataFrame
+            df = pd.DataFrame.from_dict(predecessor_data[0])
+
+            # Write to CSV and save
             df.to_csv(**self.options)
+            return df.to_json()
         except Exception as e:
             raise NodeException('write csv', str(e))
 
@@ -156,7 +164,7 @@ class ManipulationNode(Node):
     def __init__(self, node_info, options=dict()):
         super().__init__(node_info, {**ManipulationNode.DEFAULT_OPTIONS, **options})
 
-    def execute(self):
+    def execute(self, predecessor_data):
         pass
 
     def validate(self):

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -192,6 +192,25 @@ class JoinNode(ManipulationNode):
     def __init__(self, node_info, options=dict()):
         super().__init__(node_info, {**self.DEFAULT_OPTIONS, **options})
 
+    def execute(self, predecessor_data):
+        # Join cannot accept more than 2 input DataFrames
+        # TODO: Add more error-checking if 1, or no, DataFrames passed through
+        try:
+            if len(predecessor_data) > self.num_in:
+                raise NodeException(
+                    'execute',
+                    'JoinNode can take up to %d inputs. %d were provided' % (self.num_in, len(predecessor_data))
+                )
+
+            first_df = pd.DataFrame.from_dict(predecessor_data[0])
+            second_df = pd.DataFrame.from_dict(predecessor_data[1])
+
+            combined_df = first_df.join(second_df, lsuffix='_caller', rsuffix='_other')
+
+            return combined_df.to_json()
+        except Exception as e:
+            raise NodeException('join', str(e))
+
 
 class NodeException(Exception):
     def __init__(self, action: str, reason: str):

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -208,7 +208,7 @@ def execute_node(request, node_id):
 
         return JsonResponse({
             'message': 'Node Execution successful!',
-            'data': executed_node.data,
+            'data_file': executed_node.data,
         }, safe=False)
     except (NodeException, WorkflowException) as e:
         return JsonResponse({e.action: e.reason}, status=500)

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -124,9 +124,7 @@ def save_workflow(request):
             'filename': request.pyworkflow.file_path
         })
 
-        response = HttpResponse(combined_json, content_type='application/json')
-        response['Content-Disposition'] = 'attachment; filename=%s' % request.pyworkflow.file_path
-        return response
+        return HttpResponse(combined_json, content_type='application/json')
     except json.JSONDecodeError as e:
         return JsonResponse({'No React JSON provided': str(e)}, status=500)
     except WorkflowException as e:


### PR DESCRIPTION
This builds on the read/write of Node data to files @diegostruk1 introduced in PR #35. 

The key changes are in `pyworkflow/workflow.py` and are:
* Moves (most) file-handling to the Workflow object, using the FileStorage API. Node data is written using `store_node_data()` and read using `retrieve_node_data()`
* Adds an `execute(node_id)` method to the Workflow that orchestrates Node execution. This works by
    * Retrieving a `node_to_execute` specified by `node_id`
    * Retrieving data from any preceding Nodes
    * Passing that data to the Node's `execute()` function
    * Writing that output to a file and storing the filename in the Node's `data` attribute

~~Includes some basic error-checking/exception-handling, but not a lot.~~ You can test execution using [sample_execution.zip](https://github.com/matthew-t-smith/visual-programming/files/4428247/sample_execution.zip).

1. Move `join1.csv` and `join2.csv` to `/tmp`
2. Load `execution_workflow.json` into Postman
3. Manually execute Nodes 1-4. You should see the file names output to screen, and the "Retrieve data" test should return the data written to `/tmp`.

Edit: latest commits add more error-checking/handling. Namely, endpoints should now return a 400/500 code with message for missing data files/improper execution for most cases.

