### PR TITLE
Front-end refactoring

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -1,0 +1,128 @@
+/**
+ * Add node to server-side workflow
+ * @param {CustomNodeModel} node - JS node to add
+ * @returns {Promise<Object>} - server response
+ */
+export async function addNode(node) {
+    const payload = {...node.options, options: node.config};
+    const resp = await fetch("/node/", {
+        method: "POST",
+        body: JSON.stringify(payload)
+    });
+    const json = await resp.json();
+    if (resp.ok) {
+        console.log(json);
+        return json;
+    } else {
+        console.log("Failed to create node on back end.")
+        return Promise.resolve(json);
+    }
+}
+
+
+/**
+ * Delete node from server-side workflow
+ * @param {CustomNodeModel} node - JS node to remove
+ * @returns {Promise<Object>} - server response
+ */
+export async function deleteNode(node) {
+    const id = node.options.id;
+    const resp = await fetch(`/node/${id}`, {
+        method: "DELETE"
+    });
+    const json = await resp.json();
+    if (resp.ok) {
+        console.log(json);
+        return json
+    } else {
+        console.log("Failed to delete node on back end.")
+        return Promise.reject(json);
+    }
+}
+
+
+/**
+ * Update configuration of node in server-side workflow
+ * @param {CustomNodeModel} node - JS node to remove
+ * @param {Object} config - configuration from options form
+ * @returns {Promise<Object>} - server response (serialized node)
+ */
+export async function updateNode(node, config) {
+    node.config = config;
+    const payload = {...node.options, options: node.config};
+    const resp = await fetch(`/node/${node.options.id}`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+    });
+    const json = await resp.json();
+    if (!resp.ok) {
+        console.log("Failed to update node on back end.");
+        return Promise.reject(JSON);
+    } else {
+        console.log(json);
+        return json
+    }
+}
+
+
+/**
+ * Save front-end workflow and download server response as JSON file
+ * @param {Object} diagramData - serialized react-diagrams model
+ */
+export async function save(diagramData) {
+    const payload = JSON.stringify(diagramData);
+    const resp = await fetch("/workflow/save", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: payload
+    });
+    const json = await resp.json();
+    if (!resp.ok) {
+        return Promise.reject(json);
+    } else {
+        const dataStr = "data:text/json;charset=utf-8,"
+            + encodeURIComponent(JSON.stringify(json));
+        const anchor = document.createElement("a")
+        anchor.href = dataStr;
+        anchor.download = json.filename || "diagram.json";
+        anchor.click();
+        anchor.remove();
+    }
+}
+
+
+/**
+ * Get available nodes for node menu
+ * @returns {Promise<Object>} - server response (node menu items)
+ */
+export async function getNodes() {
+    const resp = await fetch("/nodes");
+    const json = await resp.json();
+    return resp.ok ? json : Promise.reject(json);
+}
+
+
+/**
+ * Start a new workflow on the server
+ * @returns {Promise<Object>} - server response
+ */
+export async function initWorkflow() {
+    const resp = await fetch("/workflow/new");
+    const json = await resp.json();
+    return resp.ok ? json : Promise.reject(json);
+}
+
+
+/**
+ * Uploads JSON workflow file to server
+ * @param {FormData} formData - form with key `file` and value of type `File`
+ * @returns {Promise<Object>} - server response (full serialized workflow)
+ */
+export async function uploadWorkflow(formData) {
+    const resp = await fetch("/workflow/open", {
+        method: "POST",
+        body: formData
+    });
+    const json = await resp.json();
+    return resp.ok ? json : Promise.reject(json);
+}

--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -1,22 +1,37 @@
 /**
+ * Sends request to server via fetch API and handles error cases
+ * @param {string} endpoint - server endpoint
+ * @param {Object} options - options parameter for `fetch` call
+ * @returns {Promise<Object>} - server response or error
+ */
+function fetchWrapper(endpoint, options = {}) {
+       return new Promise((resolve, reject) => {
+        fetch(endpoint, options)
+            .then(async resp => {
+                const data = await resp.json();
+                console.log(data);
+                if (resp.ok) return resolve(data);
+                else return reject(data);
+            })
+            .catch(err => {
+                return reject(err);
+            });
+    });
+}
+
+
+/**
  * Add node to server-side workflow
  * @param {CustomNodeModel} node - JS node to add
  * @returns {Promise<Object>} - server response
  */
 export async function addNode(node) {
     const payload = {...node.options, options: node.config};
-    const resp = await fetch("/node/", {
+    const options = {
         method: "POST",
         body: JSON.stringify(payload)
-    });
-    const json = await resp.json();
-    if (resp.ok) {
-        console.log(json);
-        return json;
-    } else {
-        console.log("Failed to create node on back end.")
-        return Promise.resolve(json);
-    }
+    };
+    return fetchWrapper("/node/", options);
 }
 
 
@@ -27,17 +42,10 @@ export async function addNode(node) {
  */
 export async function deleteNode(node) {
     const id = node.options.id;
-    const resp = await fetch(`/node/${id}`, {
+    const options = {
         method: "DELETE"
-    });
-    const json = await resp.json();
-    if (resp.ok) {
-        console.log(json);
-        return json
-    } else {
-        console.log("Failed to delete node on back end.")
-        return Promise.reject(json);
-    }
+    };
+    return fetchWrapper(`/node/${id}`, options);
 }
 
 
@@ -50,18 +58,11 @@ export async function deleteNode(node) {
 export async function updateNode(node, config) {
     node.config = config;
     const payload = {...node.options, options: node.config};
-    const resp = await fetch(`/node/${node.options.id}`, {
+    const options = {
         method: "POST",
         body: JSON.stringify(payload)
-    });
-    const json = await resp.json();
-    if (!resp.ok) {
-        console.log("Failed to update node on back end.");
-        return Promise.reject(JSON);
-    } else {
-        console.log(json);
-        return json
-    }
+    };
+    return fetchWrapper(`/node/${node.options.id}`, options)
 }
 
 
@@ -71,23 +72,20 @@ export async function updateNode(node, config) {
  */
 export async function save(diagramData) {
     const payload = JSON.stringify(diagramData);
-    const resp = await fetch("/workflow/save", {
+    const options = {
         method: "POST",
-        headers: {"Content-Type": "application/json"},
         body: payload
-    });
-    const json = await resp.json();
-    if (!resp.ok) {
-        return Promise.reject(json);
-    } else {
-        const dataStr = "data:text/json;charset=utf-8,"
-            + encodeURIComponent(JSON.stringify(json));
-        const anchor = document.createElement("a")
-        anchor.href = dataStr;
-        anchor.download = json.filename || "diagram.json";
-        anchor.click();
-        anchor.remove();
-    }
+    };
+    fetchWrapper("/workflow/save", options)
+        .then(json => {
+            const dataStr = "data:text/json;charset=utf-8,"
+                + encodeURIComponent(JSON.stringify(json));
+            const anchor = document.createElement("a")
+            anchor.href = dataStr;
+            anchor.download = json.filename || "diagram.json";
+            anchor.click();
+            anchor.remove();
+        }).catch(err => console.log(err));
 }
 
 
@@ -96,9 +94,7 @@ export async function save(diagramData) {
  * @returns {Promise<Object>} - server response (node menu items)
  */
 export async function getNodes() {
-    const resp = await fetch("/nodes");
-    const json = await resp.json();
-    return resp.ok ? json : Promise.reject(json);
+    return fetchWrapper("/nodes");
 }
 
 
@@ -107,9 +103,7 @@ export async function getNodes() {
  * @returns {Promise<Object>} - server response
  */
 export async function initWorkflow() {
-    const resp = await fetch("/workflow/new");
-    const json = await resp.json();
-    return resp.ok ? json : Promise.reject(json);
+    return fetchWrapper("/workflow/new");
 }
 
 
@@ -119,10 +113,9 @@ export async function initWorkflow() {
  * @returns {Promise<Object>} - server response (full serialized workflow)
  */
 export async function uploadWorkflow(formData) {
-    const resp = await fetch("/workflow/open", {
+    const options = {
         method: "POST",
         body: formData
-    });
-    const json = await resp.json();
-    return resp.ok ? json : Promise.reject(json);
+    };
+    return fetchWrapper("/workflow/open", options);
 }

--- a/front-end/src/components/CustomLink/CustomLinkFactory.js
+++ b/front-end/src/components/CustomLink/CustomLinkFactory.js
@@ -8,11 +8,11 @@ export class CustomLinkFactory extends DefaultLinkFactory {
         super('advanced');
     }
 
-    generateModel(): CustomLinkModel {
+    generateModel() {
       return new CustomLinkModel();
     }
 
-    generateLinkSegment(model: CustomLinkModel, selected: boolean, path: string) {
+    generateLinkSegment(model, selected, path) {
         return (
           <g>
             <CustomLinkWidget model={model} path={path} />

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -5,6 +5,7 @@ import StatusLight from '../StatusLight';
 import GraphView from './GraphView';
 import NodeConfig from './NodeConfig';
 import '../../styles/CustomNode.css';
+import * as API from '../../API';
 
 export class CustomNodeWidget extends React.Component {
 
@@ -29,36 +30,18 @@ export class CustomNodeWidget extends React.Component {
     }
 
     // delete node from diagram model and redraw diagram
-    async handleDelete() {
-        const id = this.props.node.options.id;
-        const resp = await fetch(`/node/${id}`, {
-            method: "DELETE"
-        });
-        if (resp.status !== 200) {
-            console.log("Failed to delete node on back end.")
-        } else {
+    handleDelete() {
+        API.deleteNode(this.props.node).then(() => {
             this.props.node.remove();
             this.props.engine.repaintCanvas();
-            console.log(await resp.json());
-        }
+        }).catch(err => console.log(err));
     }
 
-    async acceptConfiguration(formData) {
-        this.props.node.config = formData;
-        console.log(formData);
-        const node = this.props.node;
-        const payload = {...node.options, options: node.config};
-        const resp = await fetch(`/node/${node.options.id}`, {
-            method: "POST",
-            body: JSON.stringify(payload)
-        });
-        if (resp.status !== 200) {
-            console.log("Failed to update node on back end.")
-        } else {
-            console.log(await resp.json());
+    acceptConfiguration(formData) {
+        API.updateNode(this.props.node, formData).then(() => {
             this.forceUpdate();
             this.props.engine.repaintCanvas();
-        }
+        }).catch(err => console.log(err));
     }
 
     render() {

--- a/front-end/src/components/NodeMenu.js
+++ b/front-end/src/components/NodeMenu.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import * as _ from 'lodash';
+import { Col } from 'react-bootstrap';
+
+
+export default function NodeMenu(props) {
+    // construct menu from JSON of node types
+    return (
+        <Col xs={2} className="node-menu">
+            <div>Drag-and-drop nodes to build a workflow.</div>
+            <hr />
+            {_.map(props.nodes, (items, section) =>
+                <div key={`node-menu-${section}`}>
+                    <b>{section}</b>
+                    <ul>
+                        { _.map(items, item => {
+                            const config = item.options;
+                            delete item.options;
+                            return (
+                                <NodeMenuItem key={item.node_key} nodeInfo={item} config={config} />
+                            )}
+                        )}
+                    </ul>
+                </div>
+            )}
+        </Col>
+    );
+}
+
+
+function NodeMenuItem(props) {
+    return (
+        <li className="NodeMenuItem"
+            draggable={true}
+            onDragStart={event => {
+                event.dataTransfer.setData(
+                    'storm-diagram-node',
+                    JSON.stringify(props));
+            }}
+            style={{ color: props.nodeInfo.color }}>
+            {props.nodeInfo.name}
+        </li>
+    )
+}

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import * as _ from 'lodash';
 import { Row, Col, Button } from 'react-bootstrap';
 import createEngine, { DiagramModel } from '@projectstorm/react-diagrams';
 import { CanvasWidget } from '@projectstorm/react-canvas-core';
@@ -7,6 +6,7 @@ import { VPLinkFactory } from './VPLink/VPLinkFactory';
 import { CustomNodeModel } from './CustomNode/CustomNodeModel';
 import { CustomNodeFactory } from './CustomNode/CustomNodeFactory';
 import { VPPortFactory } from './VPPort/VPPortFactory';
+import NodeMenu from './NodeMenu';
 import '../styles/Workspace.css';
 
 class Workspace extends React.Component {
@@ -104,22 +104,6 @@ class Workspace extends React.Component {
     }
 
     render() {
-        // construct menu from JSON of node types
-        const menu = _.map(this.state.nodes, (items, section) =>
-            <div key={`node-menu-${section}`}>
-                <b>{section}</b>
-                <ul>
-                { _.map(items, item => {
-                    const config = item.options;
-                    delete item.options;
-                    return (
-                        <NodeMenuItem key={item.node_key} nodeInfo={item} config={config} />
-                    )}
-                )}
-                </ul>
-            </div>
-        );
-
         return (
             <>
                 <Row className="mb-3">
@@ -130,11 +114,7 @@ class Workspace extends React.Component {
                     </Col>
                 </Row>
                 <Row className="Workspace">
-                    <Col xs={2} className="node-menu">
-                        <div>Drag-and-drop nodes to build a workflow.</div>
-                        <hr />
-                        { menu }
-                    </Col>
+                    <NodeMenu nodes={this.state.nodes} />
                     <Col xs={10}>
                         <div style={{position: 'relative', flexGrow: 1}}
                             onDrop={event => this.handleNodeCreation(event)}
@@ -146,22 +126,6 @@ class Workspace extends React.Component {
             </>
         );
     }
-}
-
-
-function NodeMenuItem(props) {
-    return (
-        <li className="NodeMenuItem"
-            draggable={true}
-            onDragStart={event => {
-                event.dataTransfer.setData(
-                    'storm-diagram-node',
-                    JSON.stringify(props));
-            }}
-            style={{ color: props.nodeInfo.color }}>
-            {props.nodeInfo.name}
-        </li>
-    )
 }
 
 

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -28,8 +28,10 @@ class Workspace extends React.Component {
     }
 
     componentDidMount() {
-        API.getNodes().then(nodes => this.setState({nodes: nodes}));
-        API.initWorkflow().then(graph => console.log(graph));
+        API.getNodes()
+            .then(nodes => this.setState({nodes: nodes}))
+            .catch(err => console.log(err));
+        API.initWorkflow().catch(err => console.log(err));
     }
 
     /**
@@ -48,7 +50,7 @@ class Workspace extends React.Component {
     clear() {
         if (window.confirm("Clear diagram? You will lose all work.")) {
             this.model.getNodes().forEach(n => n.remove());
-            API.initWorkflow().then(graph => console.log(graph));
+            API.initWorkflow().catch(err => console.log(err));
             this.engine.repaintCanvas();
         }
     }

--- a/front-end/src/styles/CustomNode.css
+++ b/front-end/src/styles/CustomNode.css
@@ -41,10 +41,11 @@
 }
 
 .custom-node-configure {
+    font-size: 1.5rem;
     cursor: pointer;
     position: absolute;
     left: 25%;
-    top: 25%;
+    top: 50%;
     transform: translate(-50%, -50%);
 }
 


### PR DESCRIPTION
- Move all API calls to functions in separate file. Allows other components to use `API.createNode()`, e.g., instead of making XHR requests and handling responses in the component. (Reduces footprint of Workspace component by almost half.)
    - All functions are async and return a promise that resolves to the expected JSON data, or rejects to the server's JSON error message
- Refactors the node menu components into their own file
- Minor diagram style tweaks
    