### PR TITLE
Upload data files during node config

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -148,3 +148,17 @@ export async function addEdge(link) {
 export async function deleteEdge(link) {
     return handleEdge(link, "DELETE");
 }
+
+
+/**
+ * Upload a data file to be stored on the server
+ * @param {FormData} formData - FormData with file and nodeId
+ * @returns {Promise<Object>} - server response
+ */
+export async function uploadDataFile(formData) {
+    const options = {
+        method: "POST",
+        body: formData
+    };
+    return fetchWrapper("/workflow/upload", options);
+}

--- a/front-end/src/components/NodeMenu.js
+++ b/front-end/src/components/NodeMenu.js
@@ -14,10 +14,11 @@ export default function NodeMenu(props) {
                     <b>{section}</b>
                     <ul>
                         { _.map(items, item => {
-                            const config = item.options;
-                            delete item.options;
+                            const data = {...item}; // copy so we can mutate
+                            const config = data.options;
+                            delete data.options;
                             return (
-                                <NodeMenuItem key={item.node_key} nodeInfo={item} config={config} />
+                                <NodeMenuItem key={data.node_key} nodeInfo={data} config={config} />
                             )}
                         )}
                     </ul>

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -75,7 +75,7 @@ class ReadCsvNode(IONode):
         'filepath_or_buffer': {
             "type": "file",
             "name": "File",
-            "desc": "File to read"
+            "desc": "CSV File"
         },
         'sep': {
             "type": "string",
@@ -96,8 +96,9 @@ class ReadCsvNode(IONode):
         try:
             # TODO: FileStorage implemented in Django to store in /tmp
             #       Better filename/path handling should be implemented.
-
-            df = pd.read_csv(**self.options)
+            kwargs = self.options.copy()  # won't copy nested dicts though
+            del kwargs["description"]
+            df = pd.read_csv(**kwargs)
             return df.to_json()
         except Exception as e:
             raise NodeException('read csv', str(e))

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -234,6 +234,12 @@ def create_node(payload):
 
     """
     json_data = json.loads(payload)
+    # for options with type 'file', replace value with FileStorage path
+    for field, info in json_data.get("option_types", dict()).items():
+        if info["type"] == "file":
+            opt_value = json_data["options"][field]
+            if opt_value is not None:
+                json_data["options"][field] = fs.path(opt_value)
 
     try:
         return node_factory(json_data)

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -155,6 +155,7 @@ def execute_workflow(request):
 
     return JsonResponse(order, safe=False)
 
+
 @swagger_auto_schema(method='get',
                      operation_summary='Retrieve sorted list of successors from a node.',
                      operation_description='Retrieves a list of successor nodes, sorted in execution order.',
@@ -196,6 +197,7 @@ def retrieve_csv(request, node_id):
 
         return response
 
+
 @swagger_auto_schema(method='post',
                      operation_summary='Uploads a file to server.',
                      operation_description='Uploads a new file to server location.',
@@ -207,9 +209,8 @@ def retrieve_csv(request, node_id):
 def upload_file(request):
     if 'file' not in request.data:
         return JsonResponse("Empty content", status=404)
-
     f = request.data['file']
-
-    fs.save(f.name, f)
-
-    return JsonResponse("File Uploaded", status=201, safe=False)
+    node_id = request.data.get('nodeId', '')
+    save_name = f"{node_id}-{f.name}"
+    fs.save(save_name, f)
+    return JsonResponse({"filename": save_name}, status=201, safe=False)


### PR DESCRIPTION
(This includes the commits from #40, so it will look much cleaner after that one is merged.)

When file is selected from configuration menu, it is uploaded to the server and saved with the filename: `<node ID>-<original name>.<original_extension>`. The configuration form submit button is disabled until the server responds. The parameter to which the file corresponds (e.g. `filepath_or_buffer` is given the value of the filename on the server.

This brought to my attention a couple of execution bugs:
- ~The filename saved in the node options doesn't have the `/tmp` prefix, so pandas cannot find it. We will need to add a step in the node update view that replaces the value with the fully qualified FileStorage name~.
- ~The description field is inserted in the node options by the browser, and since the pandas function is called with (**options), it complains that `description` is not a valid keyword arg.~

These issues are causing me to cool on the "pass the options dict as kwargs" strategy overall. Thoughts?