### PR TITLE
Initial FlowNode implementation for local/global flow variables

### DIFF
--- a/pyworkflow/pyworkflow/__init__.py
+++ b/pyworkflow/pyworkflow/__init__.py
@@ -1,3 +1,3 @@
 from .workflow import Workflow, WorkflowException
-from .node import Node, IONode, ManipulationNode, ReadCsvNode, WriteCsvNode, JoinNode, NodeException
+from .node import *
 from .node_factory import node_factory, create_node

--- a/pyworkflow/pyworkflow/__init__.py
+++ b/pyworkflow/pyworkflow/__init__.py
@@ -1,3 +1,3 @@
 from .workflow import Workflow, WorkflowException
 from .node import Node, IONode, ManipulationNode, ReadCsvNode, WriteCsvNode, JoinNode, NodeException
-from .node_factory import node_factory
+from .node_factory import node_factory, create_node

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -14,6 +14,8 @@ class Node:
         self.node_key = node_info.get('node_key')
         self.data = node_info.get('data')
 
+        self.is_global = True if node_info.get('is_global') else False
+
         # Execution options are passed up from children
         self.options = options or dict()
 
@@ -30,6 +32,48 @@ class Node:
     def __str__(self):
         return "Test"
 
+
+class FlowNode(Node):
+    """FlowNode object
+    """
+    DEFAULT_OPTIONS = {
+
+    }
+
+    def __init__(self, node_info, options=dict()):
+        super().__init__(node_info, {**FlowNode.DEFAULT_OPTIONS, **options})
+
+
+class StringNode(FlowNode):
+    """StringNode object
+
+    Allows for Strings to replace 'string' fields in Nodes
+    """
+    name = "String Input"
+    num_in = 1
+    num_out = 1
+    color = 'purple'
+
+    DEFAULT_OPTIONS = {
+        'default_value': None,
+        'var_name': 'my_var',
+    }
+
+    OPTION_TYPES = {
+        'default_value': {
+            "type": "string",
+            "name": "Default Value",
+            "desc": "Value this Node will pass as a flow variable"
+        },
+        'var_name': {
+            "type": "string",
+            "name": "Variable Name",
+            "desc": "Name of the variable to use in another Node"
+        }
+    }
+
+    def __init__(self, node_info):
+        super().__init__(node_info)
 
 class IONode(Node):
     """IONodes deal with file-handling in/out of the Workflow.

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -20,10 +20,19 @@ def node_factory(node_info):
         new_node = io_node(node_key, node_info)
     elif node_type == 'ManipulationNode':
         new_node = manipulation_node(node_key, node_info)
+    elif node_type == 'FlowNode':
+        new_node = flow_node(node_key, node_info)
     else:
         new_node = None
 
     return new_node
+
+
+def flow_node(node_key, node_info):
+    if node_key == 'StringNode':
+        return StringNode(node_info)
+    else:
+        return None
 
 
 def io_node(node_key, node_info):

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -1,5 +1,14 @@
 from .node import *
+import json
 
+
+def create_node(payload):
+    json_data = json.loads(payload)
+
+    try:
+        return node_factory(json_data)
+    except OSError as e:
+        raise NodeException('create_node', 'Problem parsing JSON')
 
 def node_factory(node_info):
     # Create a new Node with info

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -19,11 +19,11 @@ class Workflow:
         file_path: Location of a workflow file
     """
 
-    def __init__(self, graph=nx.DiGraph(), file_path=None, workflow_name='a-name'):
+    def __init__(self, graph=nx.DiGraph(), file_path=None, name='a-name'):
         #TODO: need to discuss a way to generating the workflow name. For now passing a default name.
         self._graph = graph
         self._file_path = file_path
-        self._workflow_name = workflow_name
+        self._name = name
 
     @property
     def graph(self):
@@ -77,8 +77,13 @@ class Workflow:
 
         return
 
-    def get_workflow_name(self):
-        return self._workflow_name
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name: str):
+        self._name = name
 
     def add_edge(self, node_from: Node, node_to: Node):
         """ Add a Node object to the graph.
@@ -207,7 +212,7 @@ class Workflow:
         Returns:
 
         """
-        file_name = Workflow.generate_file_name(workflow.get_workflow_name(), node_id)
+        file_name = Workflow.generate_file_name(workflow.name, node_id)
 
         try:
             return fs.save(file_name, ContentFile(data))
@@ -275,6 +280,9 @@ class Workflow:
             node_id: the id of the workflow
         """
         #TODO: need to add validation
+        if workflow_name is None:
+            workflow_name = "a-name"
+
         return workflow_name + '-' + str(node_id)
 
     @classmethod
@@ -289,7 +297,7 @@ class Workflow:
         """
         file_path = data.get('file_path')
         graph_data = data.get('graph')
-        workflow_name = data.get('workflow_name')
+        name = data.get('name')
         if graph_data is None:
             graph = None
         else:
@@ -321,7 +329,7 @@ class Workflow:
         out = dict()
         out['graph'] = self.to_graph_json()
         out['file_path'] = self.file_path
-        out['workflow_name'] = self._workflow_name
+        out['name'] = self.name
         return out
 
 

--- a/vp/node/urls.py
+++ b/vp/node/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path('', views.node, name='node'),
     path('<str:node_id>', views.handle_node, name='handle node'),
+    path('global/<str:node_id>', views.handle_node, name='handle node'),
     path('<str:node_id>/execute', views.execute_node, name='execute node'),
     path('<str:node_id>/retrieve_data', views.retrieve_data, name='retrieve data'),
     path('edge/<str:node_from_id>/<str:node_to_id>', views.handle_edge, name='handle edge')

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -251,7 +251,8 @@ def execute_node(request, node_id):
 @api_view(['GET'])
 def retrieve_data(request, node_id):
     try:
-        data = Workflow.retrieve_node_data(request.pyworkflow, node_id)
+        node_to_retrieve = request.pyworkflow.get_node(node_id)
+        data = Workflow.retrieve_node_data(node_to_retrieve)
         return JsonResponse(data, safe=False, status=200)
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=500)

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -45,17 +45,31 @@ def node(request):
             'message': 'Missing required Node information'
         }, status=400)
 
-    # Check node_id is unique in graph
-    if request.pyworkflow.get_node(new_node.node_id) is not None:
+    # Check Node is unique in the graph
+    if new_node.is_global:
+        node_exists = request.pyworkflow.get_flow_var(new_node.node_id)
+    else:
+        node_exists = request.pyworkflow.get_node(new_node.node_id)
+
+    if node_exists:
         return JsonResponse({
-            'message': 'A node with id %s already exists in the graph.' % new_node.node_id
+            'message': 'A %s with id %s already exists in the graph.' % (
+                'flow variable' if new_node.is_global else 'node',
+                new_node.node_id
+            )
         }, status=400)
 
-    # Add Node to graph
-    request.pyworkflow.update_or_add_node(new_node)
+    # Add to the graph
+    try:
+        request.pyworkflow.update_or_add_node(new_node)
+    except WorkflowException as e:
+        return JsonResponse({e.action: e.reason}, status=400)
 
     return JsonResponse({
-        'message': 'Added new node to graph with id: %s' % new_node.node_id
+        'message': 'Added new %s to graph with id: %s' % (
+            'flow variable' if new_node.is_global else 'node',
+            new_node.node_id
+        )
     })
 
 
@@ -146,8 +160,11 @@ def handle_node(request, node_id):
         405 - Method not allowed
         500 - Error processing Node change
     """
-    # Check if the graph contains the requested Node
-    retrieved_node = request.pyworkflow.get_node(node_id)
+    # Retrieve the global or local Node
+    if request.path_info.startswith('/node/global/'):
+        retrieved_node = request.pyworkflow.get_flow_var(node_id)
+    else:
+        retrieved_node = request.pyworkflow.get_node(node_id)
 
     if retrieved_node is None:
         return JsonResponse({
@@ -168,6 +185,14 @@ def handle_node(request, node_id):
                     'message': 'Node types do not match. Need correct info.',
                     'retrieved_node': str(type(retrieved_node)),
                     'updated_node': str(type(updated_node)),
+                }, status=500)
+
+            # Nodes need to be the same type to update
+            if retrieved_node.is_global != updated_node.is_global:
+                return JsonResponse({
+                    'message': 'Node scopes do not match. Need correct info.',
+                    'retrieved_node': str(retrieved_node.is_global),
+                    'updated_node': str(updated_node.is_global),
                 }, status=500)
 
             request.pyworkflow.update_or_add_node(updated_node)

--- a/vp/workflow/urls.py
+++ b/vp/workflow/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('save', views.save_workflow, name='save'),
     path('execute', views.execute_workflow, name='execute workflow'),
     path('execute/<str:node_id>/successors', views.get_successors, name='get node successors'),
+    path('globals', views.global_vars, name="retrieve global variables"),
     path('retrieve_csv/<str:node_id>', views.retrieve_csv, name='retrieve csv')
 ]

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -1,6 +1,5 @@
 import json
 import csv
-import inspect
 
 from django.http import JsonResponse, HttpResponse
 from django.conf import settings
@@ -31,7 +30,7 @@ def new_workflow(request):
     request.pyworkflow = Workflow()
     request.session.update(request.pyworkflow.to_session_dict())
 
-    return JsonResponse(request.pyworkflow.to_graph_json())
+    return JsonResponse(Workflow.to_graph_json(request.pyworkflow.graph))
 
 
 @swagger_auto_schema(method='post',
@@ -120,7 +119,8 @@ def save_workflow(request):
     try:
         combined_json = json.dumps({
             'react': json.loads(request.body),
-            'networkx': request.pyworkflow.to_graph_json(),
+            'networkx': Workflow.to_graph_json(request.pyworkflow.graph),
+            'flow_vars': Workflow.to_graph_json(request.pyworkflow.flow_vars),
             'filename': request.pyworkflow.file_path
         })
 
@@ -154,6 +154,21 @@ def execute_workflow(request):
         return JsonResponse({e.action: e.reason}, status=500)
 
     return JsonResponse(order, safe=False)
+
+
+@swagger_auto_schema(method='get',
+                     operation_summary='Retrieve list of global flow vars.',
+                     operation_description='Retrieves a list of global flow vars.',
+                     responses={
+                         200: 'List of global flow variables.',
+                         404: 'No graph exists.',
+                         500: 'Error generating the topological sort for the graph.'
+                     })
+@api_view(['GET'])
+def global_vars(request):
+    graph_data = Workflow.to_graph_json(request.pyworkflow.flow_vars)
+    return JsonResponse(graph_data["nodes"], safe=False)
+
 
 @swagger_auto_schema(method='get',
                      operation_summary='Retrieve sorted list of successors from a node.',


### PR DESCRIPTION
# How FlowNodes work as flow variables
Global flow variables are associated with a workflow (in KNIME, right-click on workflow -> 'Workflow Variables...') and local flow variables behave like regular nodes in the graph (with special red circle ports indicating a flow variable).

In KNIME, the two key pieces of information a flow variable provides are the 'var_name' and the 'default_value'. In the context of `pyworkflow`, the 'var_name' would substitute a Node option (e.g. 'filepath_or_buffer' for `ReadCsvNode`) and the 'default_value' would replace the value associated with that option.

FlowNodes are currently similar to any other Node, and local FlowNodes are created the same way. To create a global FlowNode, `is_global: true` is passed in the POST body when creating the node. Read/update/delete are performed the same way as other nodes, just at the `/node/global/<node_id>` endpoint. Global FlowNodes are stored in a new NetworkX Graph that is added to the Workflow and saved with the JSON output.

Existing endpoints should behave the same way, but some function signatures were changed slightly:
* `node.py`: `execute()` now takes a `flow_vars` parameter
* `workflow.py`: `retrieve_node_data()` is still a static method, but accepts a Node object as the argument instead of `(workflow, node_id)`. This moves Node lookup out of the retrieval step and prevents cases where the same Node is retrieved twice.
* `workflow.py`: `to_graph_json()` is now a static method that accepts a NetworkX graph, to work for both the 'graph' (workflow) and 'flow_vars'.

# Limitations/TODO
This initial implementation should serve as a good starting point for further development. Currently, if a FlowNode is connected to a Node's in-port, the FlowNode variable will replace that option within the Node. Instead, this variable should be provided as an option the user can select when configuring the Node (i.e. use this manual value OR the value from the local flow variable).

Likewise, one can perform all CRUD operations on global FlowNodes, but they cannot be connected to actual Nodes. The `/workflow/globals` endpoint returns the list of currently defined global flow variables which should be provided as a drop-down for appropriate fields when configuring a Node.

This gets at @reddigari's point from #41 re: passing Node options into pandas calls as `kwargs`. We will probably want to investigate another approach. 

There's also the question of different 'types' of ports. `ReadCsvNode` has 0 in-ports, but should accept 1 in-port for flow variables. The `PivotNode` has 1 in-port, but should have another in-port for flow variables. Is this a front-end approach where react-diagrams can prevent non-like ports from connecting? Does the back-end need to differentiate between port types or is knowing the type of Node connected enough?