### PR TITLE
Integrate execution endpoint, configure stoplight status, and download WriteCsvNode results

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -162,3 +162,22 @@ export async function uploadDataFile(formData) {
     };
     return fetchWrapper("/workflow/upload", options);
 }
+
+
+/**
+ * Get execution order of nodes in graph
+ * @returns {Promise<Object>} - server response (array of node IDs)
+ */
+export async function executionOrder() {
+    return fetchWrapper("/workflow/execute");
+}
+
+/**
+ * Execute given node on server
+ * @param {CustomNodeModel }node - node to execute
+ * @returns {Promise<Object>} - server response
+ */
+export async function execute(node) {
+    const id = node.options.id;
+    return fetchWrapper(`/node/${id}/execute`);
+}

--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -1,3 +1,6 @@
+import { downloadFile } from './utils';
+
+
 /**
  * Sends request to server via fetch API and handles error cases
  * @param {string} endpoint - server endpoint
@@ -78,13 +81,8 @@ export async function save(diagramData) {
     };
     fetchWrapper("/workflow/save", options)
         .then(json => {
-            const dataStr = "data:text/json;charset=utf-8,"
-                + encodeURIComponent(JSON.stringify(json));
-            const anchor = document.createElement("a")
-            anchor.href = dataStr;
-            anchor.download = json.filename || "diagram.json";
-            anchor.click();
-            anchor.remove();
+            downloadFile(JSON.stringify(json), "application/json",
+                json.filename || "diagram.json")
         }).catch(err => console.log(err));
 }
 
@@ -161,6 +159,28 @@ export async function uploadDataFile(formData) {
         body: formData
     };
     return fetchWrapper("/workflow/upload", options);
+}
+
+
+/**
+ * Download file by name from server
+ * @param {string} fileName - name of file to download
+ * @returns {Promise<void>}
+ */
+export async function downloadDataFile(fileName) {
+    // TODO: make this not a giant security problem
+    let contentType;
+    // can't use fetchWrapper because it assumes JSON response
+    fetch(`/workflow/download?filename=${fileName}`)
+        .then(async resp => {
+            if (!resp.ok) return Promise.reject(await resp.json());
+            contentType = resp.headers.get("content-type");
+            if (contentType.startsWith("text")) {
+                resp.text().then(data => {
+                    downloadFile(data, contentType, fileName);
+                })
+            }
+        }).catch(err => console.log(err));
 }
 
 

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -11,6 +11,7 @@ export default class CustomNodeModel extends NodeModel {
         this.options.node_id = this.options.id;
         this.config = config;
         this.configParams = options.option_types;
+        this.options.status = options.status || "unconfigured";
 
         const nIn = options.num_in === undefined ? 1 : options.num_in;
         const nOut = options.num_out === undefined ? 1 : options.num_out;
@@ -45,5 +46,9 @@ export default class CustomNodeModel extends NodeModel {
 
     deserialize(ob, engine) {
         super.deserialize(ob, engine);
+    }
+
+    setStatus(status) {
+        this.options.status = status;
     }
 }

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -83,7 +83,7 @@ export default class CustomNodeWidget extends React.Component {
                         { portWidgets["out"] }
                     </div>
                 </div>
-                <StatusLight status="unconfigured" />
+                <StatusLight status={this.props.node.options.status} />
                 <div className="custom-node-description">{this.props.node.config.description}</div>
             </div>
         );

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -39,6 +39,7 @@ export default class CustomNodeWidget extends React.Component {
 
     acceptConfiguration(formData) {
         API.updateNode(this.props.node, formData).then(() => {
+            this.props.node.setStatus("configured");
             this.forceUpdate();
             this.props.engine.repaintCanvas();
         }).catch(err => console.log(err));

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -76,6 +76,11 @@ class Workspace extends React.Component {
             let node = this.model.getNode(order[i]);
             try {
                 await API.execute(node);
+                node.setStatus("complete");
+                // repainting canvas didn't update status light, so
+                // this is hack to re-render the node widget
+                node.setSelected(true);
+                node.setSelected(false);
             } catch {
                 console.log("Stopping execution because of failure");
                 break;

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -81,6 +81,11 @@ class Workspace extends React.Component {
                 // this is hack to re-render the node widget
                 node.setSelected(true);
                 node.setSelected(false);
+                if (node.options.download_result) {
+                    // TODO: make this work for non-WriteCsvNode nodes
+                    API.downloadDataFile(node.config["path_or_buf"])
+                        .catch(err => console.log(err));
+                }
             } catch {
                 console.log("Stopping execution because of failure");
                 break;

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -25,6 +25,7 @@ class Workspace extends React.Component {
         this.load = this.load.bind(this);
         this.clear = this.clear.bind(this);
         this.handleNodeCreation = this.handleNodeCreation.bind(this);
+        this.execute = this.execute.bind(this);
     }
 
     componentDidMount() {
@@ -69,6 +70,19 @@ class Workspace extends React.Component {
         }).catch(err => console.log(err));
     }
 
+    async execute() {
+        const order = await API.executionOrder();
+        for (let i = 0; i < order.length; ++i) {
+            let node = this.model.getNode(order[i]);
+            try {
+                await API.execute(node);
+            } catch {
+                console.log("Stopping execution because of failure");
+                break;
+            }
+        }
+    }
+
     render() {
         return (
             <>
@@ -78,7 +92,8 @@ class Workspace extends React.Component {
                             Save
                         </Button>{' '}
                         <FileUpload handleData={this.load}/>{' '}
-                        <Button size="sm" onClick={this.clear}>Clear</Button>
+                        <Button size="sm" onClick={this.clear}>Clear</Button>{' '}
+                        <Button size="sm" onClick={this.execute}>Execute</Button>
                     </Col>
                 </Row>
                 <Row className="Workspace">

--- a/front-end/src/utils.js
+++ b/front-end/src/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Offer data as a file download from the browser
+ * @param {string} data - data to download
+ * @param {string} contentType - MIME type
+ * @param {string} fileName - name of downloaded file
+ */
+export function downloadFile(data, contentType, fileName) {
+    const blob = new Blob([data], {type: contentType})
+    const url = window.URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = fileName || "download";
+    anchor.click();
+    window.URL.revokeObjectURL(url);
+}

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -121,6 +121,7 @@ class ReadCsvNode(IONode):
         'filepath_or_buffer': None,
         'sep': ',',
         'header': 'infer',
+        'index_col': None
     }
 
     OPTION_TYPES = {
@@ -138,6 +139,11 @@ class ReadCsvNode(IONode):
             "type": "string",
             "name": "Column Name Row",
             "desc": "Row number with column names (0-indexed) or 'infer'"
+        },
+        'index_col': {
+            "type": "string",
+            "name": "Index Column Name",
+            "desc": "Column to use as index (facilitates joining)"
         }
     }
 
@@ -172,10 +178,31 @@ class WriteCsvNode(IONode):
     name = "Write CSV"
     num_in = 1
     num_out = 0
+    download_result = True
+
     DEFAULT_OPTIONS = {
         'path_or_buf': None,
         'sep': ',',
         'index': True,
+    }
+
+    OPTION_TYPES = {
+        "path_or_buf": {
+            "type": "string",
+            "name": "Filename",
+            "desc": "Filename to write"
+        },
+        "sep": {
+            "type": "string",
+            "name": "Delimiter",
+            "desc": "column delimiter, default ','"
+        },
+        "index": {
+            "type": "boolean",
+            "name": "Index",
+            "desc": "Write index column or not"
+        }
+
     }
 
     def __init__(self, node_info, options=dict()):

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -34,6 +34,7 @@ class Node:
 class FlowNode(Node):
     """FlowNode object
     """
+    display_name = "Flow Control"
     DEFAULT_OPTIONS = {
 
     }
@@ -73,6 +74,7 @@ class StringNode(FlowNode):
     def __init__(self, node_info):
         super().__init__(node_info)
 
+
 class IONode(Node):
     """IONodes deal with file-handling in/out of the Workflow.
 
@@ -81,6 +83,7 @@ class IONode(Node):
         Write CSV
     """
     color = 'black'
+    display_name = "I/O"
 
     DEFAULT_OPTIONS = {
         # 'file': None,
@@ -198,6 +201,7 @@ class ManipulationNode(Node):
         Multi-in
     """
     color = 'yellow'
+    display_name = "Manipulation"
 
     DEFAULT_OPTIONS = {}
 
@@ -272,6 +276,7 @@ class NodeException(Exception):
 
     def __str__(self):
         return self.action + ': ' + self.reason
+
 
 class NodeUtils:
 

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -115,7 +115,6 @@ class ReadCsvNode(IONode):
     name = "Read CSV"
     num_in = 0
     num_out = 1
-    color = 'purple'
 
     DEFAULT_OPTIONS = {
         'filepath_or_buffer': None,
@@ -234,8 +233,8 @@ class ManipulationNode(Node):
         Filter
         Multi-in
     """
-    color = 'yellow'
     display_name = "Manipulation"
+    color = 'goldenrod'
 
     DEFAULT_OPTIONS = {}
 

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -291,7 +291,7 @@ class NodeUtils:
     def validate_predecessor_data(predecessor_data_len, num_in, node_key):
         validation_failed = False
         exception_txt = ""
-        if node_key == 'WriteCsvNode' and len(predecessor_data_len) != num_in:
+        if node_key == 'WriteCsvNode' and predecessor_data_len != num_in:
                 validation_failed = True
                 exception_txt = '%s needs %d inputs. %d were provided'
         elif (node_key != 'WriteCsvNode' and predecessor_data_len > num_in):

--- a/vp/vp/views.py
+++ b/vp/vp/views.py
@@ -22,6 +22,7 @@ def info(request):
     }
     return JsonResponse(data)
 
+
 @swagger_auto_schema(method='get',
                      operation_summary='Retrieve a list of installed Nodes',
                      operation_description='Retrieves a list of installed Nodes, in JSON.',
@@ -40,7 +41,8 @@ def retrieve_nodes_for_user(request):
 
     # Iterate through node 'types'
     for parent in Node.__subclasses__():
-        data[parent.__name__] = list()
+        key = getattr(parent, "display_name", parent.__name__)
+        data[key] = list()
 
         # Iterate through node 'keys'
         for child in parent.__subclasses__():
@@ -55,8 +57,9 @@ def retrieve_nodes_for_user(request):
                 'doc': child.__doc__,
                 'options': {**parent.DEFAULT_OPTIONS, **child.DEFAULT_OPTIONS},
                 'option_types': getattr(child, "OPTION_TYPES", dict()),
+                'download_result':  getattr(child, "download_result", False)
             }
 
-            data[parent.__name__].append(child_node)
+            data[key].append(child_node)
 
     return JsonResponse(data)

--- a/vp/workflow/urls.py
+++ b/vp/workflow/urls.py
@@ -8,6 +8,6 @@ urlpatterns = [
     path('execute', views.execute_workflow, name='execute workflow'),
     path('execute/<str:node_id>/successors', views.get_successors, name='get node successors'),
     path('globals', views.global_vars, name="retrieve global variables"),
-    path('retrieve_csv/<str:node_id>', views.retrieve_csv, name='retrieve csv'),
-    path('upload', views.upload_file, name='upload file')
+    path('upload', views.upload_file, name='upload file'),
+    path('download', views.download_file, name='download file')
 ]

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -1,3 +1,4 @@
+import os
 import json
 import csv
 
@@ -228,3 +229,30 @@ def upload_file(request):
     save_name = f"{node_id}-{f.name}"
     fs.save(save_name, f)
     return JsonResponse({"filename": save_name}, status=201, safe=False)
+
+
+@swagger_auto_schema(method='get',
+                     operation_summary='Downloads a file from the server',
+                     operation_description='Downloads a file by name from the server.',
+                     responses={
+                         200: 'File downloaded',
+                         404: 'Could not read specified file'
+                     })
+@api_view(['GET'])
+def download_file(request):
+    fname = request.GET["filename"]
+    _, ext = os.path.splitext(fname)
+    content = "application/octet-stream"
+    if ext == ".csv":
+        content = "text/csv"
+    elif ext == ".json":
+        content = "application/json"
+    response = HttpResponse(content_type=content)
+    try:
+        with fs.open(fname) as f:
+            response.write(f.read())
+        return response
+    except OSError:
+        return JsonResponse({"message": "Could not find or read file"},
+                            status=404)
+

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -90,7 +90,7 @@ def open_workflow(request):
     # Construct response
     return JsonResponse({
         'react': react,
-        'networkx': request.pyworkflow.to_graph_json(),
+        'networkx': Workflow.to_graph_json(request.pyworkflow.graph),
     })
 
 
@@ -194,23 +194,6 @@ def get_successors(request, node_id):
         return JsonResponse({e.action: e.reason}, status=500)
 
     return JsonResponse(order, safe=False)
-
-
-def retrieve_csv(request, node_id):
-    if request.method == 'GET':
-        """
-        Retrieves a CSV after the associated node execution and returns it as a json.
-        Currently just using a demo CSV in workspace. 
-        """
-        # Create the HttpResponse object with the appropriate CSV header.
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename="somefilename.csv"'
-
-        writer = csv.writer(response)
-        writer.writerow(['First row', 'Foo', 'Bar', 'Baz'])
-        writer.writerow(['Second row', 'A', 'B', 'C', '"Testing"', "Here's a quote"])
-
-        return response
 
 
 @swagger_auto_schema(method='post',


### PR DESCRIPTION
- Execute button calls endpoint to get order, and synchronously hits the execute endpoint for each node.
- Status is included in the JS node model, and updated after configuration and execution. The stoplight color reflects the status (unconfigured, configured, complete).
- Include a `download_result` flag on nodes to indicate whether their output should be downloaded after execution. This applies to WriteCsvNodes for now.
    - We can't just load the "intermediate" data (in JSON format), because it's not the CSV created from the users options. So I added a vulnerable endpoint that will download an arbitrary filename. There's no node- or workflow-ID included in the filenames, so it's also open to name clashes in /tmp.
    - I know it's ugly, but I used the Django FileStorage object in the `execute` method of `ReadCsvNode`, so that the download endpoint could find the file.
- Hit download endpoint after execution of nodes with that flag.
- Removed the use of options-as-kwargs in the pandas calls in Read/Write CSV node execution methods.
- Use display names instead of class names for the node menu categories (e.g. "I/O" instead of "IONode"