### PR TITLE
Generalize file up/download; use file-system prefix instead of FileSystemStorage

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -164,20 +164,26 @@ export async function uploadDataFile(formData) {
 
 /**
  * Download file by name from server
- * @param {string} fileName - name of file to download
+ * @param {CustomNodeModel} node - node containing file to download
  * @returns {Promise<void>}
  */
-export async function downloadDataFile(fileName) {
+export async function downloadDataFile(node) {
     // TODO: make this not a giant security problem
     let contentType;
+
+    const payload = {...node.options, options: node.config};
+
     // can't use fetchWrapper because it assumes JSON response
-    fetch(`/workflow/download?filename=${fileName}`)
+    fetch(`/workflow/download`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+    })
         .then(async resp => {
             if (!resp.ok) return Promise.reject(await resp.json());
             contentType = resp.headers.get("content-type");
             if (contentType.startsWith("text")) {
                 resp.text().then(data => {
-                    downloadFile(data, contentType, fileName);
+                    downloadFile(data, contentType, node.config["path_or_buf"]);
                 })
             }
         }).catch(err => console.log(err));

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -83,7 +83,7 @@ class Workspace extends React.Component {
                 node.setSelected(false);
                 if (node.options.download_result) {
                     // TODO: make this work for non-WriteCsvNode nodes
-                    API.downloadDataFile(node.config["path_or_buf"])
+                    API.downloadDataFile(node)
                         .catch(err => console.log(err));
                 }
             } catch {

--- a/pyworkflow/pyworkflow/__init__.py
+++ b/pyworkflow/pyworkflow/__init__.py
@@ -1,3 +1,3 @@
 from .workflow import Workflow, WorkflowException
 from .node import *
-from .node_factory import node_factory, create_node
+from .node_factory import node_factory

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -16,7 +16,7 @@ class Node:
         self.node_key = node_info.get('node_key')
         self.data = node_info.get('data')
 
-        self.is_global = True if node_info.get('is_global') else False
+        self.is_global = node_info.get('is_global') is True
 
         # Execution options are passed up from children
         self.options = options or dict()

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -1,8 +1,4 @@
 import pandas as pd
-from django.core.files.storage import FileSystemStorage
-from django.conf import settings
-
-fs = FileSystemStorage(location=settings.MEDIA_ROOT)
 
 
 class Node:
@@ -217,9 +213,7 @@ class WriteCsvNode(IONode):
 
             # Write to CSV and save
             opts = self.options
-            # TODO: Remove use of Django file storage from pyworkflow nodes
-            fname = fs.path(opts["path_or_buf"])
-            df.to_csv(fname, sep=opts["sep"], index=opts["index"])
+            df.to_csv(opts["path_or_buf"], sep=opts["sep"], index=opts["index"])
             return df.to_json()
         except Exception as e:
             raise NodeException('write csv', str(e))

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -1,14 +1,5 @@
 from .node import *
-import json
 
-
-def create_node(payload):
-    json_data = json.loads(payload)
-
-    try:
-        return node_factory(json_data)
-    except OSError as e:
-        raise NodeException('create_node', 'Problem parsing JSON')
 
 def node_factory(node_info):
     # Create a new Node with info

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -351,6 +351,8 @@ class Workflow:
         graph_data = data.get('graph')
         name = data.get('name')
         flow_vars_data = data.get('flow_vars')
+        file_system = data.get('file_system')
+        
         if graph_data is None:
             graph = None
         else:
@@ -361,7 +363,7 @@ class Workflow:
         else:
             flow_vars = nx.readwrite.json_graph.node_link_graph(flow_vars_data)
 
-        return cls(graph, file_path, name, flow_vars)
+        return cls(graph, file_path, name, flow_vars, FileSystemStorage(location=file_system))
 
     @classmethod
     def from_file(cls, file_like):
@@ -391,6 +393,7 @@ class Workflow:
         out['file_path'] = self.file_path
         out['name'] = self.name
         out['flow_vars'] = Workflow.to_graph_json(self.flow_vars)
+        out['file_system'] = self._file_system.location
         return out
 
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -19,12 +19,13 @@ class Workflow:
         file_path: Location of a workflow file
     """
 
-    def __init__(self, graph=nx.DiGraph(), file_path=None, name='a-name', flow_vars=nx.Graph()):
+    def __init__(self, graph=nx.DiGraph(), file_path=None, name='a-name', flow_vars=nx.Graph(), file_system=fs):
         #TODO: need to discuss a way to generating the workflow name. For now passing a default name.
         self._graph = graph
         self._file_path = file_path
         self._name = name
         self._flow_vars = flow_vars
+        self._file_system = file_system
 
     @property
     def graph(self):

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -237,6 +237,23 @@ class Workflow:
         except RuntimeError as e:
             raise WorkflowException('execution order', 'The graph was changed while generating the execution order')
 
+    def upload_file(self, f, node_id):
+        try:
+            fname = f"{node_id}-{f.name}"
+            return self._file_system.save(fname, f)
+        except Exception as e:
+            raise WorkflowException('upload_file', str(e))
+
+    def download_file(self, node_id):
+        node = self.get_node(node_id)
+        if node is None:
+            return None
+        else:
+            fname = node.options["path_or_buf"]
+
+            return self._file_system.open(fname)
+
+
     @staticmethod
     def store_node_data(workflow, node_id, data):
         """Store Node data

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -250,7 +250,6 @@ class Workflow:
             return None
         else:
             fname = node.options["path_or_buf"]
-
             return self._file_system.open(fname)
 
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -36,6 +36,10 @@ class Workflow:
         self._graph = graph
 
     @property
+    def fs(self):
+        return self._file_system
+
+    @property
     def file_path(self):
         return self._file_path
 

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -265,7 +265,7 @@ def create_node(payload):
     json_data = json.loads(payload)
     # for options with type 'file', replace value with FileStorage path
     for field, info in json_data.get("option_types", dict()).items():
-        if info["type"] == "file":
+        if info["type"] == "file" or info["name"] == "Filename":
             opt_value = json_data["options"][field]
             if opt_value is not None:
                 json_data["options"][field] = fs.path(opt_value)

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -263,7 +263,7 @@ def create_node(request):
         if info["type"] == "file" or info["name"] == "Filename":
             opt_value = json_data["options"][field]
             if opt_value is not None:
-                json_data["options"][field] = request.pyworkflow.fs.path(opt_value)
+                json_data["options"][field] = request.pyworkflow.path(opt_value)
 
     try:
         return node_factory(json_data)

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -4,7 +4,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from pyworkflow import Workflow, WorkflowException, Node, NodeException, node_factory, create_node
+from pyworkflow import Workflow, WorkflowException, Node, NodeException, node_factory
 from rest_framework.decorators import api_view
 from drf_yasg.utils import swagger_auto_schema
 from django.conf import settings

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -69,7 +69,7 @@ def open_workflow(request):
     try:
         # TODO: file is parsed into JSON in memory;
         #       may want to save to 'fs' for large files
-        uploaded_file = request.FILES['file']
+        uploaded_file = request.FILES.get('file')
         combined_json = json.load(uploaded_file)
 
         request.pyworkflow = Workflow.from_request(combined_json['networkx'])
@@ -200,7 +200,7 @@ def get_successors(request, node_id):
                      })
 @api_view(['POST'])
 def upload_file(request):
-    f = request.FILES['file']
+    f = request.FILES.get('file')
 
     if f is None:
         return JsonResponse("Empty content", status=404)

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -9,8 +9,6 @@ from rest_framework.decorators import api_view
 from pyworkflow import Workflow, WorkflowException
 from drf_yasg.utils import swagger_auto_schema
 
-fs = FileSystemStorage(location=settings.MEDIA_ROOT)
-
 
 @swagger_auto_schema(method='get',
                      operation_summary='Create a new workflow.',
@@ -28,7 +26,8 @@ def new_workflow(request):
         200 - Created new DiGraph
     """
     # Create new Workflow
-    request.pyworkflow = Workflow()
+    fs = FileSystemStorage(location=settings.MEDIA_ROOT)
+    request.pyworkflow = Workflow(file_system=fs)
     request.session.update(request.pyworkflow.to_session_dict())
 
     return JsonResponse(Workflow.to_graph_json(request.pyworkflow.graph))

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -206,9 +206,12 @@ def upload_file(request):
         return JsonResponse("Empty content", status=404)
 
     node_id = request.POST.get('nodeId', '')
-    save_name = request.pyworkflow.upload_file(f, node_id)
 
-    return JsonResponse({"filename": save_name}, status=201, safe=False)
+    try:
+        save_name = request.pyworkflow.upload_file(f, node_id)
+        return JsonResponse({"filename": save_name}, status=201, safe=False)
+    except WorkflowException as e:
+        return JsonResponse({e.action: e.reason}, status=500)
 
 
 @swagger_auto_schema(method='post',


### PR DESCRIPTION
This PR at least partially addresses some of the bugs @reddigari summarized in #43 dealing with file naming/access.

~Workflow still relies on Django's `FileSystemStorage` API, but is now passed in to the constructor rather than being defined in multiple places: `pyworkflow/node.py` and workflow/node `views.py`. Most file operations are still handled in the `Workflow` class, but the `create_node` method can now do the following:~

```python
json_data["options"][field] = request.pyworkflow.fs.path(opt_value)
```

when a user uploads a file during node configuration, or when a download is triggered from `WriteCsv`. If a user enters `test.csv` for the output file, when the `update` endpoint is triggered, this is converted to `/tmp/test.csv` using the Workflow's file system.

This helps solve the "giant security problem" of downloads, if we switch the endpoint to POST with the Node's info. It's still hard-coded for the `WriteCsvNode` because it looks up the Node's `path_or_buf` option where the output filename is stored, but this does prevent arbitrary downloads.

~The `store_node_data` and `retrieve_node_data` static methods in Workflow haven't been updated but I think (?) these can be done easily if this approach seems good.~