### PR TITLE
Clean up Workflow methods; update naming for Workflow/edit endpoint

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -98,10 +98,16 @@ export async function getNodes() {
 
 /**
  * Start a new workflow on the server
+ * @param {DiagramModel} model - Diagram model
  * @returns {Promise<Object>} - server response
  */
-export async function initWorkflow() {
-    return fetchWrapper("/workflow/new");
+export async function initWorkflow(model) {
+    const options = {
+        method: "POST",
+        body: JSON.stringify(model.options.id)
+    };
+
+    return fetchWrapper("/workflow/new", options);
 }
 
 

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -32,7 +32,7 @@ class Workspace extends React.Component {
         API.getNodes()
             .then(nodes => this.setState({nodes: nodes}))
             .catch(err => console.log(err));
-        API.initWorkflow().catch(err => console.log(err));
+        API.initWorkflow(this.model).catch(err => console.log(err));
     }
 
     /**
@@ -51,7 +51,7 @@ class Workspace extends React.Component {
     clear() {
         if (window.confirm("Clear diagram? You will lose all work.")) {
             this.model.getNodes().forEach(n => n.remove());
-            API.initWorkflow().catch(err => console.log(err));
+            API.initWorkflow(this.model).catch(err => console.log(err));
             this.engine.repaintCanvas();
         }
     }

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -128,7 +128,7 @@ function FileUpload(props) {
         const form = new FormData();
         form.append("file", file);
         API.uploadWorkflow(form).then(json => {
-            props.handleData(json.react);
+            props.handleData(json);
         }).catch(err => {
             console.log(err);
         });

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -116,6 +116,10 @@ class Workflow:
     def name(self, name: str):
         self._name = name
 
+    @property
+    def filename(self):
+        return self.name + '.json'
+
     def add_edge(self, node_from: Node, node_to: Node):
         """ Add a Node object to the graph.
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -18,15 +18,7 @@ class Workflow:
 
     def __init__(self, name="Untitled", root_dir=None, graph=nx.DiGraph(), flow_vars=nx.Graph()):
         self._name = name
-
-        if root_dir is None:
-            root_dir = os.getcwd()
-
-        if not os.path.exists(root_dir):
-            os.makedirs(root_dir)
-
-        self._root_dir = root_dir
-
+        self._root_dir = WorkflowUtils.set_root_dir(root_dir)
         self._graph = graph
         self._flow_vars = flow_vars
 
@@ -386,6 +378,18 @@ class Workflow:
             return out
         except nx.NetworkXError as e:
             raise WorkflowException('to_session_dict', str(e))
+
+
+class WorkflowUtils:
+    @staticmethod
+    def set_root_dir(root_dir):
+        if root_dir is None:
+            root_dir = os.getcwd()
+
+        if not os.path.exists(root_dir):
+            os.makedirs(root_dir)
+
+        return root_dir
 
 
 class WorkflowException(Exception):

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -34,9 +34,8 @@ class Workflow:
     def graph(self):
         return self._graph
 
-    @staticmethod
-    def path(workflow, file_name):
-        return os.path.join(workflow.root_dir, file_name)
+    def path(self, file_name):
+        return os.path.join(self.root_dir, file_name)
 
     @property
     def root_dir(self):
@@ -240,7 +239,7 @@ class Workflow:
     def upload_file(self, uploaded_file, node_id):
         try:
             file_name = f"{node_id}-{uploaded_file.name}"
-            to_open = Workflow.path(self, file_name)
+            to_open = self.path(file_name)
 
             # TODO: Change to a stream/other method for large files?
             with open(to_open, 'wb') as f:
@@ -258,7 +257,7 @@ class Workflow:
 
         try:
             # TODO: Change to generic "file" option to allow for more than WriteCsv
-            to_open = Workflow.path(self, node.options['path_or_buf'])
+            to_open = self.path(node.options['path_or_buf'])
             return open(to_open)
         except KeyError:
             raise WorkflowException('download_file', '%s does not have an associated file' % node_id)
@@ -280,7 +279,7 @@ class Workflow:
 
         """
         file_name = Workflow.generate_file_name(workflow, node_id)
-        file_path = Workflow.path(workflow, file_name)
+        file_path = workflow.path(file_name)
 
         try:
             with open(file_path, 'w') as f:

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -263,7 +263,7 @@ def create_node(request):
         if info["type"] == "file" or info["name"] == "Filename":
             opt_value = json_data["options"][field]
             if opt_value is not None:
-                json_data["options"][field] = request.pyworkflow.path(opt_value)
+                json_data["options"][field] = Workflow.path(request.pyworkflow, opt_value)
 
     try:
         return node_factory(json_data)

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -263,7 +263,7 @@ def create_node(request):
         if info["type"] == "file" or info["name"] == "Filename":
             opt_value = json_data["options"][field]
             if opt_value is not None:
-                json_data["options"][field] = Workflow.path(request.pyworkflow, opt_value)
+                json_data["options"][field] = request.pyworkflow.path(opt_value)
 
     try:
         return node_factory(json_data)

--- a/vp/workflow/middleware.py
+++ b/vp/workflow/middleware.py
@@ -1,4 +1,4 @@
-from pyworkflow import Workflow
+from pyworkflow import Workflow, WorkflowException
 from django.http import JsonResponse
 
 
@@ -25,13 +25,16 @@ class WorkflowMiddleware:
             pass
         else:
             # All other cases, load workflow from session
-            request.pyworkflow = Workflow.from_json(request.session)
+            try:
+                request.pyworkflow = Workflow.from_json(request.session)
 
-            # Check if a graph is present
-            if request.pyworkflow.graph is None:
-                return JsonResponse({
-                    'message': 'A workflow has not been created yet.'
-                }, status=404)
+                # Check if a graph is present
+                if request.pyworkflow.graph is None:
+                    return JsonResponse({
+                        'message': 'A workflow has not been created yet.'
+                    }, status=404)
+            except WorkflowException as e:
+                return JsonResponse({e.action: e.reason}, status=500)
 
         response = self.get_response(request)
 

--- a/vp/workflow/middleware.py
+++ b/vp/workflow/middleware.py
@@ -25,7 +25,7 @@ class WorkflowMiddleware:
             pass
         else:
             # All other cases, load workflow from session
-            request.pyworkflow = Workflow.from_session(request.session)
+            request.pyworkflow = Workflow.from_json(request.session)
 
             # Check if a graph is present
             if request.pyworkflow.graph is None:

--- a/vp/workflow/urls.py
+++ b/vp/workflow/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path('new', views.new_workflow, name='new workflow'),
     path('open', views.open_workflow, name='open workflow'),
+    path('edit', views.edit_workflow, name='edit workflow'),
     path('save', views.save_workflow, name='save'),
     path('execute', views.execute_workflow, name='execute workflow'),
     path('execute/<str:node_id>/successors', views.get_successors, name='get node successors'),

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -116,11 +116,14 @@ def save_workflow(request):
     # serialized graph
     try:
         combined_json = json.dumps({
+            'filename': request.pyworkflow.filename,
             'react': json.loads(request.body),
-            'networkx': Workflow.to_graph_json(request.pyworkflow.graph),
-            'flow_vars': Workflow.to_graph_json(request.pyworkflow.flow_vars),
-            'filename': request.pyworkflow.file_path,
-            'root_dir': request.pyworkflow.root_dir,
+            'pyworkflow': {
+                'name': request.pyworkflow.name,
+                'root_dir': request.pyworkflow.root_dir,
+                'graph': Workflow.to_graph_json(request.pyworkflow.graph),
+                'flow_vars': Workflow.to_graph_json(request.pyworkflow.flow_vars),
+            }
         })
 
         return HttpResponse(combined_json, content_type='application/json')

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -74,7 +74,7 @@ def open_workflow(request):
         uploaded_file = request.FILES.get('file')
         combined_json = json.load(uploaded_file)
 
-        request.pyworkflow = Workflow.from_request(combined_json['networkx'])
+        request.pyworkflow = Workflow.from_json(combined_json['pyworkflow'])
         request.session.update(request.pyworkflow.to_session_dict())
 
         # Send back front-end workflow

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -54,12 +54,17 @@ def open_workflow(request):
         request: Django request Object, should follow the pattern:
             {
                 react: {react-diagrams JSON},
-                networkx: {networkx graph as JSON},
+                pyworkflow: {
+                    name: Workflow name,
+                    root_dir: File storage,
+                    graph: Computational graph,
+                    flow_vars: Global flow variables,
+                },
             }
 
     Raises:
         JSONDecodeError: invalid JSON data
-        KeyError: request missing either 'react' or 'networkx' data
+        KeyError: request missing either 'react' or 'pyworkflow' data
         WorkflowException: error loading JSON into NetworkX DiGraph
 
     Returns:
@@ -85,6 +90,24 @@ def open_workflow(request):
         return JsonResponse({'No React JSON provided': str(e)}, status=500)
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=404)
+
+
+@swagger_auto_schema(method='post',
+                     operation_summary='Edit workflow information',
+                     operation_description='Edits workflow information.',
+                     responses={
+                         200: 'Workflow info updated',
+                         500: 'No valid JSON in request body'
+                     })
+@api_view(['POST'])
+def edit_workflow(request):
+    try:
+        json_data = json.loads(request.body)
+        request.pyworkflow.name = json_data['name']
+
+        return JsonResponse({'message': 'Workflow successfully updated.'})
+    except Exception as e:
+        return JsonResponse({'message': str(e)}, status=404)
 
 
 @swagger_auto_schema(method='post',

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -8,13 +8,13 @@ from pyworkflow import Workflow, WorkflowException
 from drf_yasg.utils import swagger_auto_schema
 
 
-@swagger_auto_schema(method='get',
+@swagger_auto_schema(method='post',
                      operation_summary='Create a new workflow.',
                      operation_description='Creates a new workflow with empty DiGraph.',
                      responses={
                          200: 'Created new DiGraph'
                      })
-@api_view(['GET'])
+@api_view(['POST'])
 def new_workflow(request):
     """Create a new workflow.
 
@@ -23,8 +23,13 @@ def new_workflow(request):
     Return:
         200 - Created new DiGraph
     """
+    try:
+        workflow_id = json.loads(request.body)
+    except json.JSONDecodeError as e:
+        return JsonResponse({'No React model ID provided': str(e)}, status=500)
+
     # Create new Workflow
-    request.pyworkflow = Workflow(root_dir=settings.MEDIA_ROOT)
+    request.pyworkflow = Workflow(name=workflow_id, root_dir=settings.MEDIA_ROOT)
     request.session.update(request.pyworkflow.to_session_dict())
 
     return JsonResponse(Workflow.to_graph_json(request.pyworkflow.graph))

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -76,19 +76,15 @@ def open_workflow(request):
 
         request.pyworkflow = Workflow.from_request(combined_json['networkx'])
         request.session.update(request.pyworkflow.to_session_dict())
-        react = combined_json['react']
+
+        # Send back front-end workflow
+        return JsonResponse(combined_json['react'])
     except KeyError as e:
         return JsonResponse({'open_workflow': 'Missing data for ' + str(e)}, status=500)
     except json.JSONDecodeError as e:
         return JsonResponse({'No React JSON provided': str(e)}, status=500)
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=404)
-
-    # Construct response
-    return JsonResponse({
-        'react': react,
-        'networkx': Workflow.to_graph_json(request.pyworkflow.graph),
-    })
 
 
 @swagger_auto_schema(method='post',


### PR DESCRIPTION
This cleans up `pyworkflow/workflow.py` by removing unused methods, and condensing others. Namely, there was `from_session`, `from_file`, and `from_request` methods that all read in a Workflow in mostly the same way. Now, there is one `from_json` method that can load a Workflow from a file (via the 'open' endpoint) and from session (via the middleware).

Workflow attributes have been simplified to:
* name: Name of the Workflow (now defaults to `model.options.id` passed in from the front-end). An 'edit_workflow' endpoint has also been added to make this a more user-friendly name.
* root_dir: Added in #47, but Django references have been removed from `pyworkflow` to increase modularity of the package. `Workflow.path()` now handles creating valid path names for reading/saving files.
* graph: the computational graph
* flow_vars: the global flow variables, stored in a separate Graph() object.

These changes should *not* affect the existing functionality, at least for tests that contain all the required info. One area I wasn't able to test that might be affected is cases where there is missing info. The `from_json` and `to_session_dict` methods for reading/writing the Workflow now assume valid data is provided and will raise a WorkflowException if it's not there. Previously, in some situations it would assign `None` to the graph if a graph was not present, but that's not really the behavior we want (I think). Something to check/look out for.