### PR TITLE
Parameter classes

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -189,7 +189,7 @@ export async function downloadDataFile(node) {
             contentType = resp.headers.get("content-type");
             if (contentType.startsWith("text")) {
                 resp.text().then(data => {
-                    downloadFile(data, contentType, node.config["path_or_buf"]);
+                    downloadFile(data, contentType, node.config["file"]);
                 })
             }
         }).catch(err => console.log(err));

--- a/front-end/src/components/CustomNode/NodeConfig.js
+++ b/front-end/src/components/CustomNode/NodeConfig.js
@@ -85,8 +85,8 @@ function OptionInput(props) {
     }
     return (
         <Form.Group>
-                <Form.Label>{props.name}</Form.Label>
-                <div style={{fontSize: '0.7rem'}}>{props.desc}</div>
+                <Form.Label>{props.label}</Form.Label>
+                <div style={{fontSize: '0.7rem'}}>{props.docstring}</div>
                 { inputComp }
         </Form.Group>
     )

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -97,8 +97,6 @@ class ReadCsvNode(IONode):
     }
 
     def execute(self, predecessor_data, flow_vars):
-        print(self.option_values)
-        print(self.options)
         try:
             NodeUtils.replace_flow_vars(self.options, flow_vars)
             fname = self.options["file"].get_value()
@@ -107,7 +105,6 @@ class ReadCsvNode(IONode):
             df = pd.read_csv(fname, sep=sep, header=hdr)
             return df.to_json()
         except Exception as e:
-            raise e
             raise NodeException('read csv', str(e))
 
     def __str__(self):

--- a/pyworkflow/pyworkflow/parameters.py
+++ b/pyworkflow/pyworkflow/parameters.py
@@ -1,0 +1,130 @@
+import os
+
+
+class Options:
+    """
+    Descriptor for accessing node parameters as Parameter instances
+
+    Clones the values in the class variable `OPTIONS` and sets their values
+    with the values in in the instance variable `option_values`.
+    """
+
+    def __get__(self, obj, objtype):
+        # return class variable OPTIONS if invoked from class
+        if obj is None:
+            return getattr(objtype, "OPTIONS", dict())
+        # otherwise clone class's options and set values from instance
+        options = dict()
+        for k, v in obj.OPTIONS.items():
+            options[k] = v.clone()
+        for k, v in getattr(obj, "option_values", dict()).items():
+            if k in options:
+                options[k].set_value(v)
+        return options
+
+
+class OptionTypes:
+    """
+    Descriptor for accessing parameter names, types, and descriptions.
+
+    This will never reference instance parameter values, only turn the
+    class OPTIONS into a dict.
+    """
+
+    def __get__(self, obj, objtype):
+        # handle both instance- and class-callers
+        item = obj or objtype
+        if getattr(item, "OPTIONS", None) is None:
+            return dict()
+        return {k: v.to_json() for k, v in item.OPTIONS.items()}
+
+
+class Parameter:
+    type = None
+
+    def __init__(self, label="", default=None, docstring=None):
+        self._label = label
+        self._value = None
+        self._default = default
+        self._docstring = docstring
+
+    def clone(self):
+        return self.__class__(self.label, self.default, self.docstring)
+
+    def get_value(self):
+        return self._value or self.default
+
+    def set_value(self, value):
+        self._value = value
+
+    @property
+    def label(self):
+        return self._label
+
+    @property
+    def default(self):
+        return self._default
+
+    @property
+    def docstring(self):
+        return self._docstring
+
+    def validate(self):
+        raise NotImplementedError()
+
+    def to_json(self):
+        return {
+            "type": self.type,
+            "label": self.label,
+            "value": self.get_value(),
+            "docstring": self.docstring
+        }
+
+
+class FileParameter(Parameter):
+    type = "file"
+
+    def validate(self):
+        value = self.get_value()
+        if (value is None) or (not os.path.exists(value)):
+            raise ParameterValidationError(self)
+
+
+class StringParameter(Parameter):
+    type = "string"
+
+    def validate(self):
+        value = self.get_value()
+        if not isinstance(value, str):
+            raise ParameterValidationError(self)
+
+
+class IntegerParameter(Parameter):
+    type = "int"
+
+    def validate(self):
+        value = self.get_value()
+        if not isinstance(value, int):
+            raise ParameterValidationError(self)
+
+
+class BooleanParameter(Parameter):
+    type = "boolean"
+
+    def validate(self):
+        value = self.get_value()
+        if not isinstance(value, bool):
+            raise ParameterValidationError(self)
+
+
+class ParameterValidationError(Exception):
+
+    def __init__(self, parameter):
+        self.parameter = parameter
+
+    def __str__(self):
+        param = self.parameter
+        value = param.get_value()
+        value_type = type(value).__name__
+        param_type = type(param).__name__
+        return f"Invalid value '{value}' (type '{value_type}') for {param_type}"

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -93,7 +93,10 @@ class Workflow:
         # attributes to add to graph
         node_dict = node.__dict__
         for key in node_dict.keys():
-            graph.nodes[node.node_id][key] = node_dict[key]
+            out_key = key
+            if key == "option_values":
+                out_key = "options"
+            graph.nodes[node.node_id][out_key] = node_dict[key]
 
         return
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -261,7 +261,7 @@ class Workflow:
 
         try:
             # TODO: Change to generic "file" option to allow for more than WriteCsv
-            to_open = Workflow.path(self, node.options['path_or_buf'])
+            to_open = Workflow.path(self, node.options['file'].get_value())
             return open(to_open)
         except KeyError:
             raise WorkflowException('download_file', '%s does not have an associated file' % node_id)

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -252,7 +252,7 @@ class Workflow:
 
         try:
             # TODO: Change to generic "file" option to allow for more than WriteCsv
-            to_open = Workflow.path(self, node.options['file'].get_value())
+            to_open = self.path(node.options['file'].get_value())
             return open(to_open)
         except KeyError:
             raise WorkflowException('download_file', '%s does not have an associated file' % node_id)
@@ -299,7 +299,7 @@ class Workflow:
                 problem parsing the file.
         """
         try:
-            with open(Workflow.path(self, node_to_retrieve.data)) as f:
+            with open(self.path(node_to_retrieve.data)) as f:
                 return json.load(f)
         except OSError as e:
             raise WorkflowException('retrieve node data', str(e))

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -215,7 +215,7 @@ class Workflow:
                 if node_to_retrieve.node_type == 'FlowNode':
                     flow_vars.append(node_to_retrieve.options)
                 else:
-                    preceding_data.append(Workflow.retrieve_node_data(node_to_retrieve))
+                    preceding_data.append(self.retrieve_node_data(node_to_retrieve))
 
             except WorkflowException:
                 # TODO: Should this append None, skip reading, or raise exception to view?
@@ -292,8 +292,7 @@ class Workflow:
         except Exception as e:
             return None
 
-    @staticmethod
-    def retrieve_node_data(node_to_retrieve):
+    def retrieve_node_data(self, node_to_retrieve):
         """Retrieve Node data
 
         Reads a saved DataFrame, referenced by the Node's 'data' attribute.
@@ -309,7 +308,7 @@ class Workflow:
                 problem parsing the file.
         """
         try:
-            with open(node_to_retrieve.data) as f:
+            with open(Workflow.path(self, node_to_retrieve.data)) as f:
                 return json.load(f)
         except OSError as e:
             raise WorkflowException('retrieve node data', str(e))

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -260,7 +260,7 @@ def create_node(request):
     json_data = json.loads(request.body)
     # for options with type 'file', replace value with FileStorage path
     for field, info in json_data.get("option_types", dict()).items():
-        if info["type"] == "file" or info["name"] == "Filename":
+        if info["type"] == "file" or info["label"] == "Filename":
             opt_value = json_data["options"][field]
             if opt_value is not None:
                 json_data["options"][field] = Workflow.path(request.pyworkflow, opt_value)

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -247,7 +247,7 @@ def execute_node(request, node_id):
 def retrieve_data(request, node_id):
     try:
         node_to_retrieve = request.pyworkflow.get_node(node_id)
-        data = Workflow.retrieve_node_data(node_to_retrieve)
+        data = request.pyworkflow.retrieve_node_data(node_to_retrieve)
         return JsonResponse(data, safe=False, status=200)
     except WorkflowException as e:
         return JsonResponse({e.action: e.reason}, status=500)

--- a/vp/vp/views.py
+++ b/vp/vp/views.py
@@ -55,8 +55,8 @@ def retrieve_nodes_for_user(request):
                 'num_out': child.num_out,
                 'color': child.color or parent.color,
                 'doc': child.__doc__,
-                'options': {**parent.DEFAULT_OPTIONS, **child.DEFAULT_OPTIONS},
-                'option_types': getattr(child, "OPTION_TYPES", dict()),
+                'options': {k: v.get_value() for k, v in child.options.items()},
+                'option_types': child.option_types,
                 'download_result':  getattr(child, "download_result", False)
             }
 


### PR DESCRIPTION
- Adds a base `Parameter` class with subclasses for `StringParameter`, `FileParameter`, etc. These take default values, labels, and docstrings to characterize the parameter's role in the processing node.
- Every concrete node must define `OPTIONS`, a dictionary with `Parameter` values
- The descriptor classes `Options` and `OptionTypes` provide access to those options **from both the Node class and instances**.
    - Accessing `.option_types` from either the class or instance returns a dictionary representation of the defaults for use in the front end
    - Accessing `.options` from the instance returns **copies** of the default parameters, with values taken from the instance's `option_values` attribute. This attribute is what `.options` used to be. Accessing them through the `Options` descriptor allows us to use the power of the Paramter classes (e.g. validation)
- Fixes some file access logic in pyworkflow (`retrieve_node_data` is no longer static, because it needs access to the workflow's root_dir to look up filenames)


This might seem a little overly complex at first glance, and I've been staring at it for so long that I'm no longer sure it's not. But it feels like all of the boilerplate I was able to remove from `node.py` means it's worthwhile. Concrete classes no longer need to implement their own `__init__` to bubble things upward. Using descriptor-style access means the parameters must only be defined once (as `Node.OPTIONS`), and can be accessed flexibly depending on what the caller needs to know. Also means all the parameter metadata (type, docstring) no longer needs to be serialized in the networkx graph.