### PR TITLE
Displays data at each stage in tabular form

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -13,8 +13,12 @@ function fetchWrapper(endpoint, options = {}) {
             .then(async resp => {
                 const data = await resp.json();
                 console.log(data);
-                if (resp.ok) return resolve(data);
-                else return reject(data);
+                if (resp.ok) {
+                  console.log("Response is ok");
+                  return resolve(data);
+                } else {
+                  return reject(data);
+                }
             })
             .catch(err => {
                 return reject(err);
@@ -220,5 +224,5 @@ export async function execute(node) {
  * @returns {Promise<Object>} - json respnse with the data at specified state
  */
 export async function retrieveData(nodeId) {
-  return fetchWrapper(`/node/${nodeId}/retrieve_csv_data`)
+  return fetchWrapper(`/node/${nodeId}/retrieve_data`);
 }

--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -213,3 +213,12 @@ export async function execute(node) {
     const id = node.options.id;
     return fetchWrapper(`/node/${id}/execute`);
 }
+
+/**
+ * Retrieves the data at the state of the specified node
+ * @param {string }nodeId - node identifier for an execution state
+ * @returns {Promise<Object>} - json respnse with the data at specified state
+ */
+export async function retrieveData(nodeId) {
+  return fetchWrapper(`/node/${nodeId}/retrieve_csv_data`)
+}

--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -14,7 +14,6 @@ function fetchWrapper(endpoint, options = {}) {
                 const data = await resp.json();
                 console.log(data);
                 if (resp.ok) {
-                  console.log("Response is ok");
                   return resolve(data);
                 } else {
                   return reject(data);

--- a/front-end/src/components/CustomNode/CustomNodeModel.js
+++ b/front-end/src/components/CustomNode/CustomNodeModel.js
@@ -36,6 +36,10 @@ export default class CustomNodeModel extends NodeModel {
         }
     }
 
+    getNodeId() {
+      return this.options.node_id;
+    }
+
     serialize() {
         return {
             ...super.serialize(),

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -11,6 +11,7 @@ export default class GraphView extends React.Component {
       super(props);
       this.key_id = props.node.getNodeId();
       this.state = {
+        loading: false,
         rowCount: 0,
         columnCount: 0,
         data: [],
@@ -29,6 +30,7 @@ export default class GraphView extends React.Component {
 
     load = async () => {
           console.log("Loading data");
+          this.setState({loading: true})
           API.retrieveData(this.key_id)
           .then(json => {
             const keys = Object.keys(json);
@@ -40,7 +42,8 @@ export default class GraphView extends React.Component {
             this.setState({ data: json,
               keys: keys,
               columnCount: columnCount,
-              rowCount: rowCount });
+              rowCount: rowCount,
+              loading: false});
           }).catch(err => console.log(err));
     }
 
@@ -57,7 +60,6 @@ export default class GraphView extends React.Component {
       .map(() => 25 + Math.round(Math.random() * 50));
 
     Cell = ({ columnIndex, rowIndex, style }) => {
-      console.log("Showing (" + columnIndex + ", " + rowIndex + ") out of (" + this.state.columnCount + ", " + this.state.rowCount + ")");
       if (rowIndex === 0) {
         return (
           <div style={style}>
@@ -77,6 +79,10 @@ export default class GraphView extends React.Component {
 
 
     render() {
+      if (this.state.loading) {
+        return (<div>Loading data...</div>);
+      }
+
       if (this.state.columnCount < 1) {
         return (
           <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
@@ -84,6 +90,7 @@ export default class GraphView extends React.Component {
               <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
           </Modal.Header>
           <Modal.Body>
+          Loading the data might take a while depending on how big the data is.
           </Modal.Body>
           <Modal.Footer>
               <Button variant="secondary" onClick={this.onClose}>Accept</Button>
@@ -102,27 +109,20 @@ export default class GraphView extends React.Component {
                   <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
               </Modal.Header>
               <Modal.Body>
-              <div style={{height: '150px', width: '16000px', overflow: 'scroll' }}>
-              <AutoSizer onResize={this.onResize}>
-               {({height, width}) => (
               <Grid
                   ref={this.state.gridRef}
                   columnCount={this.state.columnCount}
-                  columnWidth={index => 20}
-                  height={height}
+                  columnWidth={index => 40}
+                  height={150}
                   rowCount={this.state.rowCount}
-                  rowHeight={index => this.rowHeights[index]}
-                  width={width}
+                  rowHeight={index => 20}
+                  width={480}
                 >
                   {this.Cell}
                 </Grid>
-              )}
-                </AutoSizer>
-                </div>
               </Modal.Body>
               <Modal.Footer>
                   <Button variant="secondary" onClick={this.onClose}>Accept</Button>
-                  <Button variant="secondary" onClick={this.load}>Load</Button>
               </Modal.Footer>
               </Modal>
       );

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -14,6 +14,13 @@ export default class GraphView extends React.Component {
       this.state = { data: [] };
     }
 
+    load = () => {
+          console.log("Loading data");
+          const jsonResponse = API.retrieveData(this.key_id)
+          console.log("response type: " jsonResponse)
+          this.setState({ data: jsonResponse });
+    }
+
     onClose = () => {
         this.props.toggleShow();
     };
@@ -53,6 +60,7 @@ export default class GraphView extends React.Component {
               </Modal.Body>
               <Modal.Footer>
                   <Button variant="secondary" onClick={this.onClose}>Accept</Button>
+                  <Button variant="secondary" onClick={this.load}>Load</Button>
               </Modal.Footer>
               </Modal>
       );

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -68,7 +68,7 @@ export default class GraphView extends React.Component {
 
       return (
         <div className={className} style={style}>
-          {this.state.data[this.keys[columnIndex]][rowIndex]}
+          {this.state.data[this.state.keys[columnIndex]][rowIndex.toString()] }
         </div>
       );
     }

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -21,7 +21,7 @@ export default class GraphView extends React.Component {
   }
 
   columnWidths = (index) => {
-    return 10 * this.state.keys[index].length;
+    return 10 * this.state.widths[index];
   }
 
   rowHeights = () => new Array(765)
@@ -32,6 +32,23 @@ export default class GraphView extends React.Component {
         this.props.toggleShow();
   };
 
+  computeWidths = (columnCount, rowCount, json) => {
+    const widths = new Array(columnCount);
+    const keys = Object.keys(json);
+    for (let index = 0; index < columnCount; index++) {
+        const key = keys[index];
+        widths[index] = key.length;
+        for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+          const value = json[key][rowIndex.toString()];
+          if (value != null && value.length > widths[index]) {
+            widths[index] = value.length;
+          }
+        }
+    }
+
+    return widths;
+  }
+
   load = async () => {
           this.setState({loading: true})
           API.retrieveData(this.key_id)
@@ -40,12 +57,13 @@ export default class GraphView extends React.Component {
             const columnCount = keys.length;
             const rows = Object.keys(json[keys[0]]);
             const rowCount = rows.length;
-            console.log("There are " + rowCount + " rows")
+            const widths = this.computeWidths(columnCount, rowCount, json);
             this.setState({ data: json,
               keys: keys,
               columnCount: columnCount,
               rowCount: rowCount,
-              loading: false});
+              loading: false,
+              widths: widths});
           }).catch(err => console.log(err));
     }
 

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -2,40 +2,42 @@ import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';
-import  AutoSizer from 'react-virtualized-auto-sizer';
 import * as API from "../../API";
+import '../../styles/index.css';
+
 
 export default class GraphView extends React.Component {
 
-    constructor(props) {
-      super(props);
-      this.key_id = props.node.getNodeId();
-      this.state = {
-        loading: false,
-        rowCount: 0,
-        columnCount: 0,
-        data: [],
-        keys: [],
-        gridRef: React.createRef()};
-    }
+  constructor(props) {
+    super(props);
+    this.key_id = props.node.getNodeId();
+    this.state = {
+      loading: false,
+      rowCount: 0,
+      columnCount: 0,
+      data: [],
+      keys: [],
+      gridRef: React.createRef()};
+  }
 
-  onResize = (...args) => {
-      if (this.state.gridRef.current != null) {
-        this.state.gridRef.current.resetAfterIndices({
-          columnIndex: 0,
-          shouldForceUpdate: false
-        });
-      }
+  columnWidths = (index) => {
+    return 10 * this.state.keys[index].length;
+  }
+
+  rowHeights = () => new Array(765)
+    .fill(true)
+    .map(() => 25 + Math.round(Math.random() * 50));
+
+  onClose = () => {
+        this.props.toggleShow();
   };
 
-    load = async () => {
-          console.log("Loading data");
+  load = async () => {
           this.setState({loading: true})
           API.retrieveData(this.key_id)
           .then(json => {
             const keys = Object.keys(json);
             const columnCount = keys.length;
-            console.log("There are " + columnCount + " columns");
             const rows = Object.keys(json[keys[0]]);
             const rowCount = rows.length;
             console.log("There are " + rowCount + " rows")
@@ -47,34 +49,28 @@ export default class GraphView extends React.Component {
           }).catch(err => console.log(err));
     }
 
-    onClose = () => {
-        this.props.toggleShow();
-    };
-
-    columnWidths = (index) => {
-      return 10 * this.state.keys[index].length;
-    }
-
-    rowHeights = () => new Array(765)
-      .fill(true)
-      .map(() => 25 + Math.round(Math.random() * 50));
-
     Cell = ({ columnIndex, rowIndex, style }) => {
+      const className =  columnIndex % 2
+          ? rowIndex % 2 === 0
+            ? 'GridItemOdd'
+            : 'GridItemEven'
+          : rowIndex % 2
+            ? 'GridItemOdd'
+            : 'GridItemEven';
+
       if (rowIndex === 0) {
         return (
-          <div style={style}>
+          <div className={className} style={style}>
             {this.state.keys[columnIndex]}
           </div>
         );
       }
 
-      return (<div></div>);
-
-      /*return (
-        <div style={style}>
+      return (
+        <div className={className} style={style}>
           {this.state.data[this.keys[columnIndex]][rowIndex]}
         </div>
-      );*/
+      );
     }
 
 
@@ -100,9 +96,6 @@ export default class GraphView extends React.Component {
         );
       }
 
-      console.log("Displaying data with " + this.state.columnCount + " columns");
-      console.log("Displaying data with " + this.state.rowCount + " rows");
-
       return (
               <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
               <Modal.Header>
@@ -111,6 +104,7 @@ export default class GraphView extends React.Component {
               <Modal.Body>
               <Grid
                   ref={this.state.gridRef}
+                  className="Grid"
                   columnCount={this.state.columnCount}
                   columnWidth={index => this.columnWidths(index)}
                   height={150}

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';
+import  AutoSizer from 'react-virtualized-auto-sizer';
 import * as API from "../../API";
 
 export default class GraphView extends React.Component {
@@ -9,54 +10,115 @@ export default class GraphView extends React.Component {
     constructor(props) {
       super(props);
       this.key_id = props.node.getNodeId();
-      this.columnCount = 0;
-      this.rowCount = 0;
-      this.state = { data: [] };
+      this.state = {
+        rowCount: 0,
+        columnCount: 0,
+        data: [],
+        keys: [],
+        gridRef: React.createRef()};
     }
 
-    load = () => {
+  onResize = (...args) => {
+      if (this.state.gridRef.current != null) {
+        this.state.gridRef.current.resetAfterIndices({
+          columnIndex: 0,
+          shouldForceUpdate: false
+        });
+      }
+  };
+
+    load = async () => {
           console.log("Loading data");
-          const jsonResponse = API.retrieveData(this.key_id)
-          console.log("response type: " jsonResponse)
-          this.setState({ data: jsonResponse });
+          API.retrieveData(this.key_id)
+          .then(json => {
+            const keys = Object.keys(json);
+            const columnCount = keys.length;
+            console.log("There are " + columnCount + " columns");
+            const rows = Object.keys(json[keys[0]]);
+            const rowCount = rows.length;
+            console.log("There are " + rowCount + " rows")
+            this.setState({ data: json,
+              keys: keys,
+              columnCount: columnCount,
+              rowCount: rowCount });
+          }).catch(err => console.log(err));
     }
 
     onClose = () => {
         this.props.toggleShow();
     };
 
-    columnWidths = new Array(this.columnCount)
+    columnWidths = () => new Array(1000)
       .fill(true)
       .map(() => 75 + Math.round(Math.random() * 50));
 
-    rowHeights = new Array(this.rowCount)
+    rowHeights = () => new Array(765)
       .fill(true)
       .map(() => 25 + Math.round(Math.random() * 50));
 
-    Cell = ({ columnIndex, rowIndex, style }) => (
-      <div style={style}>
-        Item {rowIndex},{columnIndex}
-      </div>
-    );
+    Cell = ({ columnIndex, rowIndex, style }) => {
+      console.log("Showing (" + columnIndex + ", " + rowIndex + ") out of (" + this.state.columnCount + ", " + this.state.rowCount + ")");
+      if (rowIndex === 0) {
+        return (
+          <div style={style}>
+            {this.state.keys[columnIndex]}
+          </div>
+        );
+      }
+
+      return (<div></div>);
+
+      /*return (
+        <div style={style}>
+          {this.state.data[this.keys[columnIndex]][rowIndex]}
+        </div>
+      );*/
+    }
 
 
     render() {
+      if (this.state.columnCount < 1) {
+        return (
+          <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
+          <Modal.Header>
+              <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+          </Modal.Body>
+          <Modal.Footer>
+              <Button variant="secondary" onClick={this.onClose}>Accept</Button>
+              <Button variant="secondary" onClick={this.load}>Load</Button>
+          </Modal.Footer>
+          </Modal>
+        );
+      }
+
+      console.log("Displaying data with " + this.state.columnCount + " columns");
+      console.log("Displaying data with " + this.state.rowCount + " rows");
+
       return (
               <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
               <Modal.Header>
                   <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
               </Modal.Header>
               <Modal.Body>
+              <div style={{height: '150px', width: '16000px', overflow: 'scroll' }}>
+              <AutoSizer onResize={this.onResize}>
+               {({height, width}) => (
               <Grid
-                  columnCount={this.columnCount}
-                  columnWidth={index => this.columnWidths[index]}
-                  height={150}
-                  rowCount={this.rowCount}
+                  ref={this.state.gridRef}
+                  columnCount={this.state.columnCount}
+                  columnWidth={index => 20}
+                  height={height}
+                  rowCount={this.state.rowCount}
                   rowHeight={index => this.rowHeights[index]}
-                  width={400}
+                  width={width}
                 >
                   {this.Cell}
                 </Grid>
+              )}
+                </AutoSizer>
+                </div>
               </Modal.Body>
               <Modal.Footer>
                   <Button variant="secondary" onClick={this.onClose}>Accept</Button>

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -51,9 +51,9 @@ export default class GraphView extends React.Component {
         this.props.toggleShow();
     };
 
-    columnWidths = () => new Array(1000)
-      .fill(true)
-      .map(() => 75 + Math.round(Math.random() * 50));
+    columnWidths = (index) => {
+      return 10 * this.state.keys[index].length;
+    }
 
     rowHeights = () => new Array(765)
       .fill(true)
@@ -112,7 +112,7 @@ export default class GraphView extends React.Component {
               <Grid
                   ref={this.state.gridRef}
                   columnCount={this.state.columnCount}
-                  columnWidth={index => 40}
+                  columnWidth={index => this.columnWidths(index)}
                   height={150}
                   rowCount={this.state.rowCount}
                   rowHeight={index => 20}

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -2,53 +2,61 @@ import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';
+import * as API from "../../API";
 
-function GraphView(props) {
+export default class GraphView extends React.Component {
 
-    const onClose = () => {
-        props.toggleShow();
+    constructor(props) {
+      super(props);
+      this.key_id = props.node.getNodeId();
+      this.columnCount = 0;
+      this.rowCount = 0;
+      this.state = { data: [] };
+    }
+
+    onClose = () => {
+        this.props.toggleShow();
     };
 
-    /*
-    * Dummy example taken from https://react-window.now.sh/#/examples/grid/variable-size
-    */
-    const columnWidths = new Array(1000)
+    columnWidths = new Array(this.columnCount)
       .fill(true)
       .map(() => 75 + Math.round(Math.random() * 50));
 
-    const rowHeights = new Array(1000)
+    rowHeights = new Array(this.rowCount)
       .fill(true)
       .map(() => 25 + Math.round(Math.random() * 50));
 
-    const Cell = ({ columnIndex, rowIndex, style }) => (
+    Cell = ({ columnIndex, rowIndex, style }) => (
       <div style={style}>
         Item {rowIndex},{columnIndex}
       </div>
     );
 
 
-    return (
-            <Modal show={props.show} onHide={props.toggleShow} centered>
-            <Modal.Header>
-                <Modal.Title><b>{props.node.options.name}</b> View</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-            <Grid
-                columnCount={1000}
-                columnWidth={index => columnWidths[index]}
-                height={150}
-                rowCount={1000}
-                rowHeight={index => rowHeights[index]}
-                width={400}
-              >
-                {Cell}
-              </Grid>
-            </Modal.Body>
-            <Modal.Footer>
-                <Button variant="secondary" onClick={onClose}>Accept</Button>
-            </Modal.Footer>
-            </Modal>
-    );
+    render() {
+      return (
+              <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
+              <Modal.Header>
+                  <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+              <Grid
+                  columnCount={this.columnCount}
+                  columnWidth={index => this.columnWidths[index]}
+                  height={150}
+                  rowCount={this.rowCount}
+                  rowHeight={index => this.rowHeights[index]}
+                  width={400}
+                >
+                  {this.Cell}
+                </Grid>
+              </Modal.Body>
+              <Modal.Footer>
+                  <Button variant="secondary" onClick={this.onClose}>Accept</Button>
+              </Modal.Footer>
+              </Modal>
+      );
+    }
 }
 
 
@@ -57,5 +65,3 @@ GraphView.propTypes = {
     toggleShow: propTypes.func,
     onClose: propTypes.func,
 }
-
-export default GraphView;

--- a/front-end/src/styles/index.css
+++ b/front-end/src/styles/index.css
@@ -11,3 +11,18 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.Grid {
+  border: 1px solid #d9dddd;
+}
+
+.GridItemEven,
+.GridItemOdd {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.GridItemEven {
+  background-color: #f8f8f0;
+}


### PR DESCRIPTION
This PR displays in tabular format the data at each stage.

First, it displays a message warning that the loading can take too long

<img width="636" alt="Screen Shot 2020-04-16 at 3 00 26 AM" src="https://user-images.githubusercontent.com/42415198/79430489-9fb8e680-7f8e-11ea-9b85-94d9144a130e.png">

If the user clicks on `load`, the data will be loaded

<img width="630" alt="Screen Shot 2020-04-16 at 3 00 37 AM" src="https://user-images.githubusercontent.com/42415198/79430530-aba4a880-7f8e-11ea-92fc-3381b0cbf6f8.png">

The issue with the background zooming in/out is still there. I will work on that in a different PR