### PR TITLE
Refined Node execution/validation; flow variable substitution

### DIFF
--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -104,7 +104,9 @@ export async function getNodes() {
 export async function initWorkflow(model) {
     const options = {
         method: "POST",
-        body: JSON.stringify(model.options.id)
+        body: JSON.stringify({
+            "id": model.options.id
+        })
     };
 
     return fetchWrapper("/workflow/new", options);

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -24,7 +24,7 @@ class Node:
             self.option_values.update(node_info["options"])
 
     def execute(self, predecessor_data, flow_vars):
-        pass
+        raise NotImplementedError()
 
     def validate(self):
         """Validate Node configuration
@@ -43,9 +43,15 @@ class Node:
 
 
 class FlowNode(Node):
-    """FlowNode object
+    """FlowNodes object.
+
+    FlowNodes do not execute. They specify a variable name and value to pass
+    to other Nodes as a way to dynamically change other parameter values.
     """
     display_name = "Flow Control"
+
+    def execute(self, predecessor_data, flow_vars):
+        return
 
 
 class StringNode(FlowNode):
@@ -82,7 +88,7 @@ class IONode(Node):
     display_name = "I/O"
 
     def execute(self, predecessor_data, flow_vars):
-        pass
+        raise NotImplementedError()
 
 
 class ReadCsvNode(IONode):
@@ -129,9 +135,6 @@ class ReadCsvNode(IONode):
             return df.to_json()
         except Exception as e:
             raise NodeException('read csv', str(e))
-
-    def __str__(self):
-        return "ReadCsvNode"
 
 
 class WriteCsvNode(IONode):
@@ -195,7 +198,7 @@ class ManipulationNode(Node):
     color = 'goldenrod'
 
     def execute(self, predecessor_data, flow_vars):
-        pass
+        raise NotImplementedError()
 
 
 class PivotNode(ManipulationNode):
@@ -303,9 +306,6 @@ class FilterNode(ManipulationNode):
             docstring='The axis to filter on.'
         )
     }
-
-    def __init__(self, node_info, options=dict()):
-        super().__init__(node_info, {**self.DEFAULT_OPTIONS, **options})
 
     def execute(self, predecessor_data, flow_vars):
         try:

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -50,10 +50,15 @@ class StringNode(FlowNode):
     color = 'purple'
 
     OPTIONS = {
-        "default_value": StringParameter("Default Value",
-                                         docstring="Value this node will pass as a flow variable"),
-        "var_name": StringParameter("Variable Name", default="my_var",
-                                    docstring="Name of the variable to use in another Node")
+        "default_value": StringParameter(
+            "Default Value",
+            docstring="Value this node will pass as a flow variable"
+        ),
+        "var_name": StringParameter(
+            "Variable Name",
+            default="my_var",
+            docstring="Name of the variable to use in another Node"
+        )
     }
 
 
@@ -88,12 +93,22 @@ class ReadCsvNode(IONode):
     num_out = 1
 
     OPTIONS = {
-        "file": FileParameter("File", docstring="CSV File"),
-        "sep": StringParameter("Delimiter", default=",", docstring="Column delimiter"),
+        "file": FileParameter(
+            "File",
+            docstring="CSV File"
+        ),
+        "sep": StringParameter(
+            "Delimiter",
+            default=",",
+            docstring="Column delimiter"
+        ),
         # user-specified headers are probably integers, but haven't figured out
         # arguments with multiple possible types
-        "header": StringParameter("Header Row", default="infer",
-                                   docstring="Row number containing column names (0-indexed)"),
+        "header": StringParameter(
+            "Header Row",
+            default="infer",
+            docstring="Row number containing column names (0-indexed)"
+        ),
     }
 
     def execute(self, predecessor_data, flow_vars):
@@ -128,9 +143,20 @@ class WriteCsvNode(IONode):
     download_result = True
 
     OPTIONS = {
-        "file": StringParameter("Filename", docstring="CSV file to write"),
-        "sep": StringParameter("Delimiter", default=",", docstring="Column delimiter"),
-        "index": BooleanParameter("Write Index", default=True, docstring="Write index as column?"),
+        "file": StringParameter(
+            "Filename",
+            docstring="CSV file to write"
+        ),
+        "sep": StringParameter(
+            "Delimiter",
+            default=",",
+            docstring="Column delimiter"
+        ),
+        "index": BooleanParameter(
+            "Write Index",
+            default=True,
+            docstring="Write index as column?"
+        ),
     }
 
     def execute(self, predecessor_data, flow_vars):
@@ -174,65 +200,48 @@ class PivotNode(ManipulationNode):
     num_in = 1
     num_out = 3
 
-    DEFAULT_OPTIONS = {
-        'index': None,
-        'values': None,
-        'columns': None,
-        'aggfunc': 'mean',
-        'fill_value': None,
-        'margins': False,
-        'dropna': True,
-        'margins_name': 'All',
-        'observed': False
-    }
-
-    OPTION_TYPES = {
-        'index': {
-            "type": "column, grouper, array or list",
-            "name": "Index",
-            "desc": "Column to aggregate"
-        },
-        'values': {
-            "type": "column, grouper, array or list",
-            "name": "Values",
-            "desc": "Column name to use to populate new frame's values"
-        },
-        'columns': {
-            "type": "column, grouper, array or list",
-            "name": "Column Name Row",
-            "desc": "Column(s) to use for populating new frame values.'"
-        },
-        'aggfunc': {
-            "type": "function, list of functions, dict, default numpy.mean",
-            "name": "Aggregation function",
-            "desc": "Function used for aggregation"
-        },
-        'fill_value': {
-            "type": "scalar",
-            "name": "Fill value",
-            "desc": "Value to replace missing values with"
-        },
-        'margins': {
-            "type": "boolean",
-            "name": "Margins name",
-            "desc": "Add all rows/columns"
-        },
-
-        'dropna': {
-            "type": "boolean",
-            "name": "Drop NaN columns",
-            "desc": "Ignore columns with all NaN entries"
-        },
-        'margins_name': {
-            "type": "string",
-            "name": "Margins name",
-            "desc": "Name of the row/column that will contain the totals when margins is True"
-        },
-        'observed': {
-            "type": "string",
-            "name": "Column Name Row",
-            "desc": "Row number with column names (0-indexed) or 'infer'"
-        }
+    OPTIONS = {
+        'index': StringParameter(
+            'Index',
+            docstring='Column to aggregate (column, grouper, array or list)'
+        ),
+        'values': StringParameter(
+            'Values',
+            docstring='Column name to use to populate new frame\'s values (column, grouper, array or list)'
+        ),
+        'columns': StringParameter(
+            'Column Name Row',
+            docstring='Column(s) to use for populating new frame values. (column, grouper, array or list)'
+        ),
+        'aggfunc': StringParameter(
+            'Aggregation function',
+            default='mean',
+            docstring='Function used for aggregation (function, list of functions, dict, default numpy.mean)'
+        ),
+        'fill_value': StringParameter(
+            'Fill value',
+            docstring='Value to replace missing values with (scalar)'
+        ),
+        'margins': BooleanParameter(
+            'Margins name',
+            default=False,
+            docstring='Add all rows/columns'
+        ),
+        'dropna': BooleanParameter(
+            'Drop NaN columns',
+            default=True,
+            docstring='Ignore columns with all NaN entries'
+        ),
+        'margins_name': StringParameter(
+            'Margins name',
+            default='All',
+            docstring='Name of the row/column that will contain the totals when margins is True'
+        ),
+        'observed': BooleanParameter(
+            'Column Name Row',
+            default=False,
+            docstring='Row number with column names (0-indexed) or "infer"'
+        )
     }
 
     def execute(self, predecessor_data, flow_vars):
@@ -273,34 +282,23 @@ class FilterNode(ManipulationNode):
     num_in = 1
     num_out = 1
 
-    DEFAULT_OPTIONS = {
-        'items': None,
-        'like': None,
-        'regex': None,
-        'axis': None
-    }
-
-    OPTION_TYPES = {
-        'items': {
-            "type": "list",
-            "name": "Items",
-            "desc": "Keep labels from axis which are in items"
-        },
-        'like': {
-            "type": "string",
-            "name": "Like",
-            "desc": "Keep labels from axis for which like in label == True."
-        },
-        'regex': {
-            "type": "string",
-            "name": "Regex",
-            "desc": "Keep labels from axis for which re.search(regex, label) == True."
-        },
-        'axis': {
-            "type": "int or string",
-            "name": "Axis",
-            "desc": "The axis to filter on."
-        }
+    OPTIONS = {
+        'items': StringParameter(
+            'Items',
+            docstring='Keep labels from axis which are in items'
+        ),
+        'like': StringParameter(
+            'Like',
+            docstring='Keep labels from axis for which like in label == True.'
+        ),
+        'regex': StringParameter(
+            'Regex',
+            docstring='Keep labels from axis for which re.search(regex, label) == True.'
+        ),
+        'axis': StringParameter(
+            'Axis',
+            docstring='The axis to filter on.'
+        )
     }
 
     def __init__(self, node_info, options=dict()):

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -27,7 +27,16 @@ class Node:
         pass
 
     def validate(self):
-        return True
+        """Validate Node configuration
+
+        Checks all Node options and validates all Parameter classes using
+        their validation method.
+
+        Raises:
+            ParameterValidationError: invalid Parameter value
+        """
+        for option in self.options.values():
+            option.validate()
 
     def __str__(self):
         return "Test"
@@ -74,9 +83,6 @@ class IONode(Node):
 
     def execute(self, predecessor_data, flow_vars):
         pass
-
-    def validate(self):
-        return True
 
 
 class ReadCsvNode(IONode):
@@ -190,9 +196,6 @@ class ManipulationNode(Node):
 
     def execute(self, predecessor_data, flow_vars):
         pass
-
-    def validate(self):
-        return True
 
 
 class PivotNode(ManipulationNode):

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -87,6 +87,18 @@ class Node:
                 f'{self.node_key} requires {self.num_in} inputs. {num_input_data} were provided'
             )
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "node_id": self.node_id,
+            "node_type": self.node_type,
+            "node_key": self.node_key,
+            "data": self.data,
+            "is_global": self.is_global,
+            "option_values": self.option_values,
+            "option_replace": self.option_replace,
+        }
+
     def __str__(self):
         return "Test"
 

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -30,7 +30,7 @@ class Node:
     def execute(self, predecessor_data, flow_vars):
         raise NotImplementedError()
 
-    def replace_flow_vars(self, flow_vars):
+    def get_execution_options(self, flow_nodes):
         """Replace Node options with flow variables.
 
         If the user has specified any flow variables to replace Node options,
@@ -39,7 +39,7 @@ class Node:
         a copy of all Node options unchanged.
 
         Args:
-            flow_vars: dict of variables to replace options
+            flow_nodes: dict of FlowNodes used to replace options
 
         Returns:
             dict containing options to use for execution
@@ -50,9 +50,8 @@ class Node:
         #       If none are included, we can just return `self.options`.
         for key, option in self.options.items():
 
-            if key in flow_vars:
-                replacement = flow_vars[key].get_replacement_value()
-                option.set_value(replacement)
+            if key in flow_nodes:
+                option.set_value(flow_nodes[key].get_replacement_value())
 
             execution_options[key] = option
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -61,6 +61,31 @@ class Workflow:
         node_info = self.flow_vars.nodes[node_id]
         return node_factory(node_info)
 
+    def get_all_flow_var_options(self, node_id):
+        """Retrieve all FlowNode options for a specified Node.
+
+        A Node can use all global FlowNodes, and any connected local FlowNodes
+        for variable substitution.
+
+        Args:
+            node_id: The Node to GET
+
+        Returns:
+            list of all FlowNode objects, converted to JSON
+        """
+        # Add global FlowNodes
+        graph_data = Workflow.to_graph_json(self.flow_vars)
+        flow_variables = graph_data['nodes']
+
+        # Append local FlowNodes
+        for predecessor_id in self.get_node_predecessors(node_id):
+            node = self.get_node(predecessor_id)
+
+            if node.node_type == 'FlowNode':
+                flow_variables.append(node.to_json())
+
+        return flow_variables
+
     def update_or_add_node(self, node: Node):
         """ Update or add a Node object to the graph.
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -2,7 +2,7 @@ import os
 import networkx as nx
 import json
 
-from .node import Node
+from .node import Node, NodeException
 from .node_factory import node_factory
 
 
@@ -55,7 +55,7 @@ class Workflow:
         Return:
             FlowNode object, if one exists. Otherwise, None.
         """
-        if self._flow_vars.has_node(node_id) is not True:
+        if self.flow_vars.has_node(node_id) is not True:
             return None
 
         node_info = self.flow_vars.nodes[node_id]
@@ -180,37 +180,84 @@ class Workflow:
         if node_to_execute is None:
             raise WorkflowException('execute', 'The workflow does not contain node %s' % node_id)
 
-        # Read in any data from predecessor/flow nodes
-        # TODO: This should work for local FlowNodes, but global flow_vars still
-        #       need a way to be assigned/replace Node options
-        preceding_data = list()
-        flow_vars = list()
-        for predecessor in self.get_node_predecessors(node_id):
-            try:
-                node_to_retrieve = self.get_node(predecessor)
+        # Load predecessor data and FlowNode values
+        preceding_data = self.load_input_data(node_to_execute.node_id)
+        flow_nodes = self.load_flow_var_values(node_to_execute.option_replace)
 
-                if node_to_retrieve is None:
-                    raise WorkflowException('retrieve node data', 'The workflow does not contain node %s' % node_id)
+        try:
+            # Validate input data, and replace flow variables
+            node_to_execute.validate_input_data(len(preceding_data))
+            execution_options = node_to_execute.replace_flow_vars(flow_nodes)
 
-                if node_to_retrieve.node_type == 'FlowNode':
-                    flow_vars.append(node_to_retrieve.options)
-                else:
-                    preceding_data.append(self.retrieve_node_data(node_to_retrieve))
+            # Pass in data to current Node to use in execution
+            output = node_to_execute.execute(preceding_data, execution_options)
 
-            except WorkflowException:
-                # TODO: Should this append None, skip reading, or raise exception to view?
-                preceding_data.append(None)
-
-        # Pass in data to current Node to use in execution
-        output = node_to_execute.execute(preceding_data, flow_vars)
-
-        # Save new execution data to disk
-        node_to_execute.data = Workflow.store_node_data(self, node_id, output)
+            # Save new execution data to disk
+            node_to_execute.data = Workflow.store_node_data(self, node_id, output)
+        except NodeException as e:
+            raise e
 
         if node_to_execute.data is None:
             raise WorkflowException('execute', 'There was a problem saving node output.')
 
         return node_to_execute
+
+    def load_flow_var_values(self, options):
+        """Construct dict of FlowNodes indexed by option name.
+
+        Args:
+            options: Flow variables user selected for a given Node.
+
+        Returns:
+            dict of FlowNode objects, indexed by the option name.
+        """
+        flow_vars = dict()
+
+        for key, option in options.items():
+            try:
+                flow_node_id = option["node_id"]
+
+                if option["is_global"]:
+                    flow_node = self.get_flow_var(flow_node_id)
+                else:
+                    flow_node = self.get_node(flow_node_id)
+
+                if flow_node is None or flow_node.node_type != 'FlowNode':
+                    raise WorkflowException('load flow vars', 'The workflow does not contain FlowNode %s' % flow_node_id)
+
+                flow_vars[key] = flow_node
+            except WorkflowException:
+                # TODO: Should this add a blank value, skip reading, or raise exception to view?
+                continue
+
+        return flow_vars
+
+    def load_input_data(self, node_id):
+        """Construct list of predecessor DataFrames
+
+        Args:
+            node_id: The Node with predecessors
+
+        Returns:
+            list of dict-like DataFrames, used for Node execution
+        """
+        input_data = list()
+
+        for predecessor_id in self.get_node_predecessors(node_id):
+            try:
+                node_to_retrieve = self.get_node(predecessor_id)
+
+                if node_to_retrieve is None:
+                    raise WorkflowException('retrieve node data', 'The workflow does not contain node %s' % predecessor_id)
+
+                if node_to_retrieve.node_type != 'FlowNode':
+                    input_data.append(self.retrieve_node_data(node_to_retrieve))
+
+            except WorkflowException:
+                # TODO: Should this append None, skip reading, or raise exception to view?
+                continue
+
+        return input_data
 
     def execution_order(self):
         try:

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -66,14 +66,7 @@ class Workflow:
 
         Args:
             node - The Node object to update or add to the graph
-
-        TODO:
-            * validate() always returns True; this should perform actual validation
         """
-        # Do not add/update if invalid
-        if node.validate() is False:
-            raise WorkflowException('update_or_add_node', 'Node is invalid')
-
         # Select the correct graph to modify
         graph = self.flow_vars if node.is_global else self.graph
 
@@ -112,9 +105,6 @@ class Workflow:
 
         Returns:
             Tuple representing the new Edge (from, to)
-
-        TODO:
-            * validate() always returns True; this should perform actual validation
         """
         # Prevent duplicate edges between the same two nodes
         # TODO: This may be incorrect usage for a `node_to` that has multi-in
@@ -124,8 +114,7 @@ class Workflow:
         if self._graph.has_edge(from_id, to_id):
             raise WorkflowException('add_node', 'Edge between nodes already exists.')
 
-        if node_from.validate() and node_to.validate():
-            self._graph.add_edge(from_id, to_id)
+        self._graph.add_edge(from_id, to_id)
 
         return (from_id, to_id)
 

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -167,7 +167,6 @@ def handle_node(request, node_id):
         }, status=404)
 
     # Process request
-    # Node class not JSON serializable; pass __dict__ to response for display
     try:
         if request.method == 'GET':
             response = JsonResponse(retrieved_node.__dict__, safe=False)
@@ -194,7 +193,7 @@ def handle_node(request, node_id):
             updated_node.validate()
 
             request.pyworkflow.update_or_add_node(updated_node)
-            response = JsonResponse(updated_node.__dict__, safe=False)
+            response = JsonResponse(updated_node.to_json(), safe=False)
         elif request.method == 'DELETE':
             request.pyworkflow.remove_node(retrieved_node)
             response = JsonResponse({

--- a/vp/node/views.py
+++ b/vp/node/views.py
@@ -169,7 +169,10 @@ def handle_node(request, node_id):
     # Process request
     try:
         if request.method == 'GET':
-            response = JsonResponse(retrieved_node.__dict__, safe=False)
+            response = JsonResponse({
+                "retrieved_node": retrieved_node.to_json(),
+                "flow_variables": request.pyworkflow.get_all_flow_var_options(node_id),
+            }, safe=False)
         elif request.method == 'POST':
             updated_node = create_node(request)
 

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -25,14 +25,14 @@ def new_workflow(request):
     """
     try:
         workflow_id = json.loads(request.body)
-    except json.JSONDecodeError as e:
+
+        # Create new Workflow
+        request.pyworkflow = Workflow(name=workflow_id['id'], root_dir=settings.MEDIA_ROOT)
+        request.session.update(request.pyworkflow.to_session_dict())
+
+        return JsonResponse(Workflow.to_graph_json(request.pyworkflow.graph))
+    except (json.JSONDecodeError, KeyError) as e:
         return JsonResponse({'No React model ID provided': str(e)}, status=500)
-
-    # Create new Workflow
-    request.pyworkflow = Workflow(name=workflow_id, root_dir=settings.MEDIA_ROOT)
-    request.session.update(request.pyworkflow.to_session_dict())
-
-    return JsonResponse(Workflow.to_graph_json(request.pyworkflow.graph))
 
 
 @swagger_auto_schema(method='post',


### PR DESCRIPTION
# Node execution/validation
The main Node class now implements a validation method that checks all Parameters, calling their `option.validate()` methods. The calls to validate within `pyworkflow/workflow.py` have also been removed. This addresses the use case mentioned where a Node could potentially be invalid when added to the workspace. Now, Nodes are validated upon saving the configuration, or the 'node update' endpoint.

Also changed is the order of operations for Node execution. The main logic in the `Workflow` class has been simplified to:
```python
# Load predecessor data and FlowNode values
preceding_data = self.load_input_data(node_to_execute.node_id)
flow_nodes = self.load_flow_nodes(node_to_execute.option_replace)

# Validate input data, and replace flow variables
node_to_execute.validate_input_data(len(preceding_data))
execution_options = node_to_execute.get_execution_options(flow_nodes)

# Pass in data to current Node to use in execution
output = node_to_execute.execute(preceding_data, execution_options)
```

The thinking behind moving input data validation and flow variable substitution into the Workflow class, is anyone developing a custom Node would not have to duplicate this work. Even for the built-in Nodes there was a lot of duplication where each Node validated input and parameters.

The `validate_input_data` and newly-named `get_execution_options` were moved from the `NodeUtils` class into the main `Node` class. This approach seems cleaner to me, but there may be use cases I'm not considering.

# Flow variable substitution
There are currently no front-end options to create or pass these flow variables around, but this PR should handle most of the back-end functionality and updates the endpoint responses for the front-end to use. Currently, flow variables work by adding the following attributes to a Node (for example `ReadCsv`, written here in JSON:
```json
"option_replace": {
    "sep": {
        "node_id": "2",
        "is_global": true
    }
}
```
On execution, the back-end would substitute the `default_value` stored in the global `FlowNode` with ID "2", for whatever the current value is for "sep" in the `ReadCsvNode`. Should the user want to revert "sep" back to whatever stored value was there, they would remove the flow variable (perhaps a checkbox, or empty selection from a dropdown?).

To pull this information in to the "Node Configuration" pop-up in the front-end, the action would need to call the `GET /node/{node_id}` endpoint which has been updated to return the Node's information as well as any flow variable options (all global variables, and any local variables connected as predecessors).

# TODO:
This PR updates all Nodes to use the `Parameter` classes @reddigari introduced in #53. Only `Read/WriteCsv` and the `JoinNode` have been updated to use these Parameters during execution; the rest still pass in `**self.options`) which may cause issues.

There is no validation to ensure a FlowNode matches the Parameter type of a given option. E.g., there are no checks to prevent a `StringNode` value from replacing a `BooleanParameter` value.

Integration with front-end. Nested-forms might be the solution to provide the JSON data the back-end currently is using, but both back/front might need some changes as we integrate.
