### PR TITLE
Fixes zooming in/out while scrolling

### DIFF
--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from "react";
 import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';
@@ -91,6 +91,14 @@ export default class GraphView extends React.Component {
       );
     }
 
+    preventDefault = (e) => {
+      e = e || window.event;
+      e.stopPropagation();
+    }
+
+    outerElementType = forwardRef((props, ref) => (
+        <div ref={ref} onWheel={this.preventDefault} {...props} />
+    ));
 
     render() {
       if (this.state.loading) {
@@ -129,6 +137,7 @@ export default class GraphView extends React.Component {
                   rowCount={this.state.rowCount}
                   rowHeight={index => 20}
                   width={480}
+                  outerElementType={this.outerElementType}
                 >
                   {this.Cell}
                 </Grid>

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef } from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';


### PR DESCRIPTION
When we view the data in tabular form for each state while scrolling it causes the background to zoom in/out. This PR fixes this issue so the background doesn't receive the scrolling notifications