### PR TITLE
Fix scrolling/zoom issue from all modals

### DIFF
--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -3,7 +3,7 @@ import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';
 import * as API from "../../API";
-import '../../styles/index.css';
+import '../../styles/GraphView.css';
 
 
 export default class GraphView extends React.Component {

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -116,26 +116,26 @@ export default class GraphView extends React.Component {
       }
 
       return (
-              <Modal show={this.props.show} onHide={this.props.toggleShow} centered
-                  onWheel={e => e.stopPropagation()}>
+          <Modal show={this.props.show} onHide={this.props.toggleShow} centered
+              onWheel={e => e.stopPropagation()}>
               <Modal.Header closeButton>
                   <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
               </Modal.Header>
               <Modal.Body>
-              <Grid
-                  ref={this.state.gridRef}
-                  className="Grid"
-                  columnCount={this.state.columnCount}
-                  columnWidth={index => this.columnWidths(index)}
-                  height={150}
-                  rowCount={this.state.rowCount}
-                  rowHeight={index => 20}
-                  width={480}
-                >
-                  {this.Cell}
-                </Grid>
+                  <Grid
+                      ref={this.state.gridRef}
+                      className="Grid"
+                      columnCount={this.state.columnCount}
+                      columnWidth={index => this.columnWidths(index)}
+                      height={150}
+                      rowCount={this.state.rowCount}
+                      rowHeight={index => 20}
+                      width={480}
+                    >
+                      {this.Cell}
+                    </Grid>
               </Modal.Body>
-              </Modal>
+          </Modal>
       );
     }
 }

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -99,7 +99,8 @@ export default class GraphView extends React.Component {
 
       if (this.state.columnCount < 1) {
         return (
-          <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
+          <Modal show={this.props.show} onHide={this.props.toggleShow} centered
+             onWheel={e => e.stopPropagation()}>
           <Modal.Header>
               <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
           </Modal.Header>
@@ -115,7 +116,8 @@ export default class GraphView extends React.Component {
       }
 
       return (
-              <Modal show={this.props.show} onHide={this.props.toggleShow} centered>
+              <Modal show={this.props.show} onHide={this.props.toggleShow} centered
+                  onWheel={e => e.stopPropagation()}>
               <Modal.Header>
                   <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
               </Modal.Header>

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -108,7 +108,7 @@ export default class GraphView extends React.Component {
           Loading the data might take a while depending on how big the data is.
           </Modal.Body>
           <Modal.Footer>
-              <Button variant="secondary" onClick={this.onClose}>Accept</Button>
+              <Button variant="secondary" onClick={this.onClose}>Cancel</Button>
               <Button variant="secondary" onClick={this.load}>Load</Button>
           </Modal.Footer>
           </Modal>
@@ -118,7 +118,7 @@ export default class GraphView extends React.Component {
       return (
               <Modal show={this.props.show} onHide={this.props.toggleShow} centered
                   onWheel={e => e.stopPropagation()}>
-              <Modal.Header>
+              <Modal.Header closeButton>
                   <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
               </Modal.Header>
               <Modal.Body>
@@ -135,9 +135,6 @@ export default class GraphView extends React.Component {
                   {this.Cell}
                 </Grid>
               </Modal.Body>
-              <Modal.Footer>
-                  <Button variant="secondary" onClick={this.onClose}>Accept</Button>
-              </Modal.Footer>
               </Modal>
       );
     }

--- a/front-end/src/components/CustomNode/NodeConfig.js
+++ b/front-end/src/components/CustomNode/NodeConfig.js
@@ -28,7 +28,8 @@ export default function NodeConfig(props) {
     };
 
     return (
-            <Modal show={props.show} onHide={props.toggleShow} centered>
+            <Modal show={props.show} onHide={props.toggleShow} centered
+                onWheel={e => e.stopPropagation()}>
                 <Form onSubmit={handleSubmit} ref={form}>
                     <Modal.Header>
                         <Modal.Title><b>{props.node.options.name}</b> Configuration</Modal.Title>

--- a/front-end/src/styles/GraphView.css
+++ b/front-end/src/styles/GraphView.css
@@ -1,0 +1,14 @@
+.Grid {
+    border: 1px solid #d9dddd;
+    width: auto;
+}
+
+.GridItemEven, .GridItemOdd {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.GridItemEven {
+    background-color: #f8f8f0;
+}

--- a/front-end/src/styles/index.css
+++ b/front-end/src/styles/index.css
@@ -12,17 +12,3 @@ code {
     monospace;
 }
 
-.Grid {
-  border: 1px solid #d9dddd;
-}
-
-.GridItemEven,
-.GridItemOdd {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.GridItemEven {
-  background-color: #f8f8f0;
-}


### PR DESCRIPTION
I found a more universal way to prevent the scrolling/zoom issue. Closing #58 for now.

- Stops propagation of wheel events from modals, so it doesn't bubble up to the canvas
- Changes button names per #60 (just uses a corner "x" to close the data view)