### PR TITLE
Initial upload/instantiation of custom nodes

### DIFF
--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -14,7 +14,7 @@ def node_factory(node_info):
     elif node_type == 'FlowNode':
         new_node = flow_node(node_key, node_info)
     else:
-        new_node = None
+        new_node = custom_node(node_type, node_key, node_info)
 
     return new_node
 
@@ -45,4 +45,16 @@ def manipulation_node(node_key, node_info):
     elif node_key == 'FilterNode':
         return FilterNode(node_info)
     else:
+        return None
+
+def custom_node(filename, node_key, node_info):
+    try:
+        package = __import__('custom_nodes.' + filename)
+        module = getattr(package, filename)
+        my_class = getattr(module, node_key)
+        instance = my_class(node_info)
+
+        return instance
+    except Exception as e:
+        print(str(e))
         return None

--- a/pyworkflow/pyworkflow/node_factory.py
+++ b/pyworkflow/pyworkflow/node_factory.py
@@ -47,6 +47,7 @@ def manipulation_node(node_key, node_info):
     else:
         return None
 
+
 def custom_node(filename, node_key, node_info):
     try:
         package = __import__('custom_nodes.' + filename)

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -19,8 +19,13 @@ class Workflow:
     def __init__(self, name="Untitled", root_dir=None, graph=nx.DiGraph(), flow_vars=nx.Graph()):
         self._name = name
         self._root_dir = WorkflowUtils.set_root_dir(root_dir)
+        self._custom_node_dir = WorkflowUtils.set_custom_nodes_dir()
         self._graph = graph
         self._flow_vars = flow_vars
+
+    @property
+    def custom_node_dir(self):
+        return self._custom_node_dir
 
     @property
     def graph(self):
@@ -404,6 +409,15 @@ class Workflow:
 
 
 class WorkflowUtils:
+    @staticmethod
+    def set_custom_nodes_dir():
+        custom_node_dir = os.path.join(os.getcwd(), '../pyworkflow/custom_nodes')
+
+        if not os.path.exists(custom_node_dir):
+            os.makedirs(custom_node_dir)
+
+        return custom_node_dir
+
     @staticmethod
     def set_root_dir(root_dir):
         if root_dir is None:

--- a/vp/vp/urls.py
+++ b/vp/vp/urls.py
@@ -39,7 +39,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('info/', views.info),
     path('nodes/', views.retrieve_nodes_for_user),
-    path('custom_nodes/', views.retrieve_custom_nodes_for_user),
     path('node/', include('node.urls')),
     path('workflow/', include('workflow.urls'))
 ]

--- a/vp/vp/urls.py
+++ b/vp/vp/urls.py
@@ -39,6 +39,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('info/', views.info),
     path('nodes/', views.retrieve_nodes_for_user),
+    path('custom_nodes/', views.retrieve_custom_nodes_for_user),
     path('node/', include('node.urls')),
     path('workflow/', include('workflow.urls'))
 ]

--- a/vp/vp/views.py
+++ b/vp/vp/views.py
@@ -2,9 +2,11 @@ from django.http import JsonResponse
 from rest_framework.decorators import api_view
 from drf_yasg.utils import swagger_auto_schema
 from pyworkflow import Node
+from modulefinder import ModuleFinder
 
 import os
 import inspect
+import sys
 
 
 @swagger_auto_schema(method='get', responses={200:'JSON response with data'})
@@ -42,78 +44,84 @@ def retrieve_nodes_for_user(request):
     """
     data = dict()
 
-    # Iterate through node 'types'
+    # Iterate through installed Nodes
     for parent in Node.__subclasses__():
         key = getattr(parent, "display_name", parent.__name__)
         data[key] = list()
 
         # Iterate through node 'keys'
         for child in parent.__subclasses__():
-            # TODO: check attribute-scope is handled correctly
-            child_node = {
-                'name': child.name,
-                'node_key': child.__name__,
-                'node_type': parent.__name__,
-                'num_in': child.num_in,
-                'num_out': child.num_out,
-                'color': child.color or parent.color,
-                'doc': child.__doc__,
-                'options': {k: v.get_value() for k, v in child.options.items()},
-                'option_types': child.option_types,
-                'download_result':  getattr(child, "download_result", False)
-            }
+            node = extract_node_info(parent, child)
+            data[key].append(node)
 
-            data[key].append(child_node)
+    # Check for any installed Custom Nodes
+    # TODO: Workflow loading excluded in middleware for this route
+    #       Should probably have a way to access the 'custom_node` dir dynamically
+    custom_node_path = os.path.join(os.getcwd(), '../pyworkflow/custom_nodes')
+    data['CustomNode'] = import_custom_node(custom_node_path)
 
     return JsonResponse(data)
 
 
-@swagger_auto_schema(method='get',
-                     operation_summary='Retrieve a list of custom Nodes',
-                     operation_description='Retrieves a list of custom Nodes, in JSON.',
-                     responses={
-                         200: 'List of installed Nodes, in JSON',
-                     })
-@api_view(['GET'])
-def retrieve_custom_nodes_for_user(request):
-    data = dict()
+def check_missing_packages(node_path):
+    finder = ModuleFinder(node_path)
+    finder.run_script(node_path)
 
-    # TODO: Workflow loading excluded in middleware for this route
-    #       Should probably have a way to access the 'custom_node` dir dynamically
-    custom_node_path = os.path.join(os.getcwd(), '../pyworkflow/custom_nodes')
+    uninstalled = list()
+    for missing_package in finder.badmodules.keys():
+        if missing_package not in sys.modules:
+            uninstalled.append(missing_package)
 
+    return uninstalled
+
+
+def extract_node_info(parent, child):
+    # TODO: check attribute(s) accessing is handled correctly
+    return {
+        'name': child.name,
+        'node_key': child.__name__,
+        'node_type': str(parent),
+        'num_in': child.num_in,
+        'num_out': child.num_out,
+        'color': child.color or parent.color or 'black',
+        'doc': child.__doc__,
+        'options': {k: v.get_value() for k, v in child.options.items()},
+        'option_types': child.option_types,
+        'download_result': getattr(child, "download_result", False)
+    }
+
+
+def import_custom_node(root_path):
+    # Get list of files in path
     try:
-        nodes = os.listdir(custom_node_path)
+        files = os.listdir(root_path)
     except OSError as e:
-        return JsonResponse({"message": str(e)}, status=500)
+        return None
 
-    for node in nodes:
-        # Parse file type
-        node_name, ext = os.path.splitext(node)
+    data = list()
+    for file in files:
+        # Check file is not a dir
+        node_path = os.path.join(root_path, file)
+        if not os.path.isfile(node_path):
+            continue
+
+        node, ext = os.path.splitext(file)
 
         try:
-            package = __import__('custom_nodes.' + node_name)
-            module = getattr(package, node_name)
-        except ModuleNotFoundError as e:
-            # TODO: This will only catch the first missing package. Can we get more?
-            data[node_name] = f"Please install missing packages and restart the server. Missing '{e.name}'"
+            package = __import__('custom_nodes.' + node)
+            module = getattr(package, node)
+        except ModuleNotFoundError:
+            data.append({
+                "name": node,
+                "missing_packages": check_missing_packages(node_path)
+            })
             continue
 
         for name, klass in inspect.getmembers(module):
             if inspect.isclass(klass) and klass.__module__.startswith('custom_nodes.'):
-                custom_node = {
-                    'name': klass.name,
-                    'node_key': name,
-                    'node_type': node_name,
-                    'num_in': klass.num_in,
-                    'num_out': klass.num_out,
-                    'color': klass.color or 'black',
-                    'doc': klass.__doc__,
-                    'options': {k: v.get_value() for k, v in klass.options.items()},
-                    'option_types': klass.option_types,
-                    'download_result': getattr(klass, "download_result", False)
-                }
+                custom_node = extract_node_info(node, klass)
+                data.append(custom_node)
 
-                data[node_name] = custom_node
+    return data
 
-    return JsonResponse(data, safe=False)
+

--- a/vp/workflow/urls.py
+++ b/vp/workflow/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path('execute/<str:node_id>/successors', views.get_successors, name='get node successors'),
     path('globals', views.global_vars, name="retrieve global variables"),
     path('upload', views.upload_file, name='upload file'),
-    path('download', views.download_file, name='download file')
+    path('download', views.download_file, name='download file'),
+    path('custom_node', views.add_custom_node, name='add custom node')
 ]

--- a/vp/workflow/views.py
+++ b/vp/workflow/views.py
@@ -217,6 +217,33 @@ def get_successors(request, node_id):
 
 
 @swagger_auto_schema(method='post',
+                     operation_summary='Uploads a custom node to server.',
+                     operation_description='Uploads a custom node to server location.',
+                     responses={
+                         200: 'File uploaded',
+                         404: 'No specified file'
+                     })
+@api_view(['POST'])
+def add_custom_node(request):
+    node_file = request.FILES.get('file')
+
+    if node_file is None:
+        return JsonResponse("Empty content", status=404)
+
+    to_open = os.path.join(request.pyworkflow.custom_node_dir, node_file.name)
+
+    try:
+        with open(to_open, 'wb') as f:
+            f.write(node_file.read())
+    except OSError as e:
+        return JsonResponse({'message': str(e)}, status=500)
+
+    node_file.close()
+
+    return JsonResponse({"filename": to_open}, status=201, safe=False)
+
+
+@swagger_auto_schema(method='post',
                      operation_summary='Uploads a file to server.',
                      operation_description='Uploads a new file to server location.',
                      responses={


### PR DESCRIPTION
We probably want to hold off on merging until we figure some issues out, but this PR has *an* implementation of adding custom nodes. Other approaches/questions are discussed in #67.

### What this *does*
* Provides a `POST /workflow/custom_node` endpoint  that accepts a file and adds it to a `custom_nodes` directory within `pyworkflow`.
* ~Provides a `GET /custom_nodes` endpoint that parses any files located within `custom_nodes`. This returns a JSON-representation of the nodes similar to the `GET /nodes` endpoint for "system nodes".~ Adds to the existing `GET /nodes` endpoint for system nodes, but now adds searching/parsing of files located within `custom_nodes`.
* For custom nodes containing packages not currently installed/available, ~it adds a message telling the user to install the packages and restart the server.~ it compiles a list of packages and is keyed as `missing_packages` in the JSON response.
* Adds creating custom nodes to the `node_factory`. 

### What this *does not* do/things to fix
* Custom nodes are currently stored in `pyworkflow/custom_nodes` so that they can import the `Node` class to extend. We may or may not want to stored custom nodes separately from the package, in which case we'll need a way to reference `Node`.
    * The custom node path is hardcoded. We should provide a way to dynamically specify a path (within the `root_dir`, or elsewhere).
* There's a lot of duplicate code to handle the uploading of the custom node file. It mirrors a lot of the `upload_file` methods in `workflow.py` and the Workflow view. If we want to pursue this approach, we should refactor uploading to accept different kinds of files and for different purposes.
* This does not install any missing packages. Execution works for packages specified in our `Pipfile` (like pandas), but this should be addressed.