### PR TITLE
Remove postgres Python dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ verify_ssl = true
 autopep8 = "~=1.5"
 django = "~=3.0.4"
 pandas = "~=1.0.1"
-psycopg2 = "~=2.8.4"
 python-dotenv = "~=0.12.0"
 networkx = "~=2.4"
 pyworkflow = {path = "./pyworkflow",editable = true}

--- a/vp/vp/settings.py
+++ b/vp/vp/settings.py
@@ -82,12 +82,7 @@ WSGI_APPLICATION = 'vp.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 ### Not yet setup
-DATABASES = {
-    # 'default': {
-    #     'ENGINE': 'django.db.backends.postgresql',
-    #     'NAME': os.path.join(BASE_DIR, 'db.postgresql'),
-    # }
-}
+DATABASES = {}
 
 MEDIA_ROOT = '/tmp'
 


### PR DESCRIPTION
`psycopg` mucks up `pipenv install` for me on macOS and Linux, so let's remove it before the TAs try to build our project?