### PR TITLE
Reads to stdin and writes to stdout, batch execution of workflows

### DIFF
--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -20,34 +20,35 @@ def cli():
 
 
 @cli.command()
-@click.argument('filename', type=click.Path(exists=True))
+@click.argument('filename', type=click.Path(exists=True), nargs=-1)
 def execute(filename):
 
-    stdin_files = []
+    #execute each one of the workflows in the ar
+    for workflow_file in filename:
 
-    if not click.get_text_stream('stdin').isatty():
-        stdin_text = click.get_text_stream('stdin')
+        stdin_files = []
 
-        # TODO should be done for each separate file coming from stdin, currently working for one file, but easy to build up.
+        if not click.get_text_stream('stdin').isatty():
+            stdin_text = click.get_text_stream('stdin')
 
-        # write standard in to a new file in local filesystem
-        file_name = str(uuid.uuid4())
+            # write standard in to a new file in local filesystem
+            file_name = str(uuid.uuid4())
 
-        # TODO small issue here, might be better to upload this file to the workflow directory instead of cwd
-        new_file_path = os.path.join(os.getcwd(), file_name)
+            # TODO small issue here, might be better to upload this file to the workflow directory instead of cwd
+            new_file_path = os.path.join(os.getcwd(), file_name)
 
-        # read from std in and upload a new file in project directory
-        with open(new_file_path, 'w') as f:
-            f.write(stdin_text.read())
+            # read from std in and upload a new file in project directory
+            with open(new_file_path, 'w') as f:
+                f.write(stdin_text.read())
 
-        stdin_files.append(file_name)
+            stdin_files.append(file_name)
 
-    if filename is None:
-        click.echo('Please specify a workflow to run')
-        return
-    try:
-        click.echo('Loading workflow file form %s' % filename)
-        Workflow.execute_workflow(filename, stdin_files)
-    except NodeException as ne:
-        click.echo("Issues during node execution")
-        click.echo(ne)
+        if workflow_file is None:
+            click.echo('Please specify a workflow to run')
+            return
+        try:
+            click.echo('Loading workflow file form %s' % workflow_file)
+            Workflow.execute_workflow(workflow_file, stdin_files)
+        except NodeException as ne:
+            click.echo("Issues during node execution")
+            click.echo(ne)

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 import os
 import uuid
@@ -17,19 +19,29 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @pass_config
 def cli(config, file_directory):
     config.file_directory = file_directory
-    stdin_text = click.get_text_stream('stdin')
+
     stdin_files = []
 
-    #write standard in to a new file in local filesystem
-    #TODO should be done for each separate file coming from stdin
+    if not click.get_text_stream('stdin').isatty():
 
-    file_name = str(uuid.uuid4())
-    new_file_path = os.path.join(os.getcwd(), file_name)
-    #read from std in and upload a new file in project directory
-    with open(new_file_path, 'w') as f:
-        f.write(stdin_text.read())
-    stdin_files.append(file_name)
+        stdin_text = click.get_text_stream('stdin')
+
+        # TODO should be done for each separate file coming from stdin, currently working for one file, but easy to build up.
+
+        #write standard in to a new file in local filesystem
+        file_name = str(uuid.uuid4())
+
+        # TODO small issue here, might be better to upload this file to the workflow directory instead of cwd
+        new_file_path = os.path.join(os.getcwd(), file_name)
+
+        #read from std in and upload a new file in project directory
+        with open(new_file_path, 'w') as f:
+            f.write(stdin_text.read())
+
+        stdin_files.append(file_name)
+
     config.stdin_files = stdin_files
+
 
 @cli.command()
 @pass_config

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -15,7 +15,8 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @pass_config
 def cli(config, file_directory):
     if file_directory is None:
-        file_directory = '.'
+        click.echo('Please specify a workflow to run')
+        return
     config.file_directory = file_directory
 
 
@@ -26,5 +27,5 @@ def execute(config):
         click.echo('Loading workflow file form %s' % config.file_directory)
         Workflow.execute_workflow(config.file_directory)
     except NodeException as ne:
-        click.echo("Issues during node exception")
+        click.echo("Issues during node execution")
         click.echo(ne)

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -23,6 +23,8 @@ def cli():
 @click.argument('filename', type=click.Path(exists=True), nargs=-1)
 def execute(filename):
 
+    write_to_stdout = not click.get_text_stream('stdout').isatty()
+
     #execute each one of the workflows in the ar
     for workflow_file in filename:
 
@@ -43,12 +45,17 @@ def execute(filename):
 
             stdin_files.append(file_name)
 
+
+
         if workflow_file is None:
             click.echo('Please specify a workflow to run')
             return
         try:
-            click.echo('Loading workflow file form %s' % workflow_file)
-            Workflow.execute_workflow(workflow_file, stdin_files)
+            if not write_to_stdout:
+                click.echo('Loading workflow file from %s' % workflow_file)
+            Workflow.execute_workflow(workflow_file, stdin_files, write_to_stdout)
+
+
         except NodeException as ne:
             click.echo("Issues during node execution")
             click.echo(ne)

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -15,43 +15,39 @@ class Config(object):
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
 @click.group()
-@click.option('--file-directory', type=click.Path())
-@pass_config
-def cli(config, file_directory):
-    config.file_directory = file_directory
+def cli():
+    pass
+
+
+@cli.command()
+@click.argument('filename', type=click.Path(exists=True))
+def execute(filename):
 
     stdin_files = []
 
     if not click.get_text_stream('stdin').isatty():
-
         stdin_text = click.get_text_stream('stdin')
 
         # TODO should be done for each separate file coming from stdin, currently working for one file, but easy to build up.
 
-        #write standard in to a new file in local filesystem
+        # write standard in to a new file in local filesystem
         file_name = str(uuid.uuid4())
 
         # TODO small issue here, might be better to upload this file to the workflow directory instead of cwd
         new_file_path = os.path.join(os.getcwd(), file_name)
 
-        #read from std in and upload a new file in project directory
+        # read from std in and upload a new file in project directory
         with open(new_file_path, 'w') as f:
             f.write(stdin_text.read())
 
         stdin_files.append(file_name)
 
-    config.stdin_files = stdin_files
-
-
-@cli.command()
-@pass_config
-def execute(config):
-    if config.file_directory is None:
+    if filename is None:
         click.echo('Please specify a workflow to run')
         return
     try:
-        click.echo('Loading workflow file form %s' % config.file_directory)
-        Workflow.execute_workflow(config.file_directory, config.stdin_files)
+        click.echo('Loading workflow file form %s' % filename)
+        Workflow.execute_workflow(filename, stdin_files)
     except NodeException as ne:
         click.echo("Issues during node execution")
         click.echo(ne)

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -1,4 +1,6 @@
 import click
+import os
+import uuid
 
 from pyworkflow import Workflow
 from pyworkflow import NodeException
@@ -15,7 +17,19 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @pass_config
 def cli(config, file_directory):
     config.file_directory = file_directory
+    stdin_text = click.get_text_stream('stdin')
+    stdin_files = []
 
+    #write standard in to a new file in local filesystem
+    #TODO should be done for each separate file coming from stdin
+
+    file_name = str(uuid.uuid4())
+    new_file_path = os.path.join(os.getcwd(), file_name)
+    #read from std in and upload a new file in project directory
+    with open(new_file_path, 'w') as f:
+        f.write(stdin_text.read())
+    stdin_files.append(file_name)
+    config.stdin_files = stdin_files
 
 @cli.command()
 @pass_config
@@ -25,7 +39,7 @@ def execute(config):
         return
     try:
         click.echo('Loading workflow file form %s' % config.file_directory)
-        Workflow.execute_workflow(config.file_directory)
+        Workflow.execute_workflow(config.file_directory, config.stdin_files)
     except NodeException as ne:
         click.echo("Issues during node execution")
         click.echo(ne)

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -14,15 +14,16 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @click.option('--file-directory', type=click.Path())
 @pass_config
 def cli(config, file_directory):
-    if file_directory is None:
-        click.echo('Please specify a workflow to run')
-        return
+    print('Unable to run file')
     config.file_directory = file_directory
 
 
 @cli.command()
 @pass_config
 def execute(config):
+    if config.file_directory is None:
+        click.echo('Please specify a workflow to run')
+        return
     try:
         click.echo('Loading workflow file form %s' % config.file_directory)
         Workflow.execute_workflow(config.file_directory)

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -14,7 +14,6 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @click.option('--file-directory', type=click.Path())
 @pass_config
 def cli(config, file_directory):
-    print('Unable to run file')
     config.file_directory = file_directory
 
 

--- a/CLI/cli.py
+++ b/CLI/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from pyworkflow import Workflow
+from pyworkflow import NodeException
 
 
 class Config(object):
@@ -21,5 +22,9 @@ def cli(config, file_directory):
 @cli.command()
 @pass_config
 def execute(config):
-    click.echo('Loading workflow file form %s' % config.file_directory)
-    Workflow.execute_workflow(config.file_directory)
+    try:
+        click.echo('Loading workflow file form %s' % config.file_directory)
+        Workflow.execute_workflow(config.file_directory)
+    except NodeException as ne:
+        click.echo("Issues during node exception")
+        click.echo(ne)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ data from `localhost:8000` **where the Django app must be running**.
 ## CLI
 1. Run pipenv shell.
 2. Create a workflow using UI and save it. 
-3. Run it as: pyworkflow --file-directory (path-to-json-workflow-file) execute
+3. Run it as: pyworkflow execute (paths-to-json-workflow-files-separated-by-space)
+  
+
 
 ---
 ## Tests

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ data from `localhost:8000` **where the Django app must be running**.
 ## CLI
 1. Run pipenv shell.
 2. Create a workflow using UI and save it. 
-3. Run it as: pyworkflow execute (paths-to-json-workflow-files-separated-by-space)
+3. Run it as: pyworkflow execute workflow-file
+
+Also accepts reading input from std (i.e < file.csv) and writing to sdt out (i.e > output.csv)
   
 
 

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -112,7 +112,6 @@ class ReadCsvNode(IONode):
     def execute_for_read(self, predecessor_data, flow_vars, file_to_read):
         try:
             fname = file_to_read
-            print(fname)
             sep = self.options["sep"].get_value()
             hdr = self.options["header"].get_value()
             df = pd.read_csv(fname, sep=sep, header=hdr)

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -109,6 +109,17 @@ class ReadCsvNode(IONode):
         except Exception as e:
             raise NodeException('read csv', str(e))
 
+    def execute_for_read(self, predecessor_data, flow_vars, file_to_read):
+        try:
+            fname = file_to_read
+            print(fname)
+            sep = self.options["sep"].get_value()
+            hdr = self.options["header"].get_value()
+            df = pd.read_csv(fname, sep=sep, header=hdr)
+            return df.to_json()
+        except Exception as e:
+            raise NodeException('read csv', str(e))
+
     def __str__(self):
         return "ReadCsvNode"
 

--- a/pyworkflow/pyworkflow/node.py
+++ b/pyworkflow/pyworkflow/node.py
@@ -97,16 +97,6 @@ class Node:
             "option_replace": self.option_replace,
         }
 
-    def execute_for_read(self, predecessor_data, flow_vars, file_to_read):
-        try:
-            fname = file_to_read
-            sep = self.options["sep"].get_value()
-            hdr = self.options["header"].get_value()
-            df = pd.read_csv(fname, sep=sep, header=hdr)
-            return df.to_json()
-        except Exception as e:
-            raise NodeException('read csv', str(e))
-
     def __str__(self):
         return "Test"
 

--- a/pyworkflow/pyworkflow/nodes/io/read_csv.py
+++ b/pyworkflow/pyworkflow/nodes/io/read_csv.py
@@ -46,3 +46,13 @@ class ReadCsvNode(IONode):
             return df.to_json()
         except Exception as e:
             raise NodeException('read csv', str(e))
+
+    def execute_for_read(self, predecessor_data, flow_vars, file_to_read):
+        try:
+            fname = file_to_read
+            sep = self.options["sep"].get_value()
+            hdr = self.options["header"].get_value()
+            df = pd.read_csv(fname, sep=sep, header=hdr)
+            return df.to_json()
+        except Exception as e:
+            raise NodeException('read csv', str(e))

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -293,8 +293,6 @@ class Workflow:
         """
         node_to_execute = self.get_node(node_id)
 
-        print(node_id)
-
         if node_to_execute is None:
             raise WorkflowException('execute', 'The workflow does not contain node %s' % node_id)
 

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -417,7 +417,7 @@ class Workflow:
         #execute each node in the order returned by execution order method
         #TODO exception handling: stop and provide details on which node failed to execute
         for node in execution_order:
-            if type(workflow_instance.get_node(node)) is ReadCsvNode:
+            if type(workflow_instance.get_node(node)) is ReadCsvNode and len(stdin_files) > 0:
                 csv_location = stdin_files[0]
                 workflow_instance.execute_read_csv(node, csv_location)
             else:

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -8,7 +8,8 @@ import sys
 from collections import OrderedDict
 from modulefinder import ModuleFinder
 
-from .node import Node, NodeException, ReadCsvNode
+from pyworkflow.nodes import ReadCsvNode
+from .node import Node, NodeException
 from .node_factory import node_factory
 
 
@@ -291,6 +292,8 @@ class Workflow:
 
         """
         node_to_execute = self.get_node(node_id)
+
+        print(node_id)
 
         if node_to_execute is None:
             raise WorkflowException('execute', 'The workflow does not contain node %s' % node_id)

--- a/pyworkflow/pyworkflow/workflow.py
+++ b/pyworkflow/pyworkflow/workflow.py
@@ -383,6 +383,10 @@ class Workflow:
             raise WorkflowException('to_session_dict', str(e))
 
     def execute_read_csv(self, node_id, csv_location):
+        # TODO: some duplicated code here from execute common method. Need to refactor.
+        """Execute read_csv from a file specified to standard input.
+                  Current use case: CLI.
+        """
         preceding_data = list()
         flow_vars = list()
         node_to_execute = self.get_node(node_id)
@@ -420,6 +424,8 @@ class Workflow:
             if type(workflow_instance.get_node(node)) is ReadCsvNode and len(stdin_files) > 0:
                 csv_location = stdin_files[0]
                 workflow_instance.execute_read_csv(node, csv_location)
+                # delete file at index 0
+                del stdin_files[0]
             else:
                 workflow_instance.execute(node)
 


### PR DESCRIPTION
- Adds logic to read from stdin:
pyworkflow execute <location-of-json-file> < input-file

1. Uploads the input file to current working directory.
2. If there is a ReadCsv node in the workflow it overrides the input file from the pyworkflow json to read from the stdin file instead.

- Adds logic to write to stdout: 
  
pyworkflow execute <location-of-json-file> > output-file

- Adds input validation and checks.
- Adds batch execution logic pyworkflow execute <location-of-json-files-separated-by-space>

TODO: 
For reading from stdin I created a method in workflow and an execute specific one in ReadCsvNode class. I would like to refactor this to re-use the already existing methods. While some basic validations are in place there is still some work needed to be done.