### PR TITLE
Allow upload of custom node files; display node docs/errors in tooltips

### DIFF
--- a/front-end/src/components/CustomNodeUpload.js
+++ b/front-end/src/components/CustomNodeUpload.js
@@ -1,0 +1,48 @@
+import React, {useRef, useState} from "react";
+import * as API from "../API";
+import {Button} from "react-bootstrap";
+
+
+export default function CustomNodeUpload({ onUpload }) {
+
+    const input = useRef(null);
+    const [status, setStatus] = useState("ready");
+
+    const uploadFile = async file => {
+        setStatus("loading");
+        const fd = new FormData();
+        fd.append("file", file);
+        API.uploadDataFile(fd)
+            .then(resp => {
+                onUpload();
+                setStatus("ready");
+            }).catch(() => {
+                setStatus("failed");
+        });
+        input.current.value = null;
+    };
+    const onFileSelect = e => {
+        e.preventDefault();
+        if (!input.current.files) return;
+        uploadFile(input.current.files[0]);
+    };
+
+    let content;
+    if (status === "loading") {
+        content = <div>Uploading file...</div>;
+    } else if (status === "failed") {
+        content = (<div>Upload failed. Try a new file.</div>);
+    }
+    return (
+        <>
+            <input type="file" ref={input} onChange={onFileSelect}
+                   style={{display: "none"}} />
+            <Button size="sm" onClick={() => input.current.click()}
+                    variant="success"
+                    disabled={status === "loading"}>
+                Add Custom Node
+            </Button>
+            {content}
+        </>
+    )
+}

--- a/front-end/src/components/NodeMenu.js
+++ b/front-end/src/components/NodeMenu.js
@@ -32,9 +32,26 @@ export default function NodeMenu(props) {
 }
 
 
+/**
+ * Format docstring with newlines into tooltip content
+ * @param string - node docstring
+ * @returns {array} - array of strings and HTML elements
+ */
+function formatTooltip(string) {
+    const split = string.split("\n");
+    const out = [];
+    split.forEach((line, i) => {
+        out.push(line);
+        out.push(<br  key={i} />);
+    });
+    out.pop();
+    return out;
+}
+
+
 function NodeMenuItem(props) {
     if (!props.nodeInfo.missing_packages) {
-        const tooltip = props.nodeInfo.doc || "This node has no documentation."
+        const tooltip = props.nodeInfo.doc ? formatTooltip(props.nodeInfo.doc) : "This node has no documentation."
         return (
             <OverlayTrigger
                 placement="right"
@@ -53,8 +70,9 @@ function NodeMenuItem(props) {
             </OverlayTrigger>
         )
     } else {
-        let tooltip = "These Python modules could not be imported: ";
-        tooltip += props.nodeInfo.missing_packages.join(", ");
+        let tooltip = "These Python modules could not be imported:\n\n"
+            + props.nodeInfo.missing_packages.join("\n");
+        tooltip = formatTooltip(tooltip);
         return (
             <OverlayTrigger
                 placement="right"
@@ -70,7 +88,11 @@ function NodeMenuItem(props) {
 // Overlay with props has to use ref forwarding
 const NodeTooltip = React.forwardRef((props, ref) => {
     return (
-        <Tooltip {...props} ref={ref}>{props.message}</Tooltip>
+        <Tooltip {...props} ref={ref}>
+            <div style={{textAlign: "left"}}>
+                {props.message}
+            </div>
+        </Tooltip>
     )
 });
 

--- a/front-end/src/components/NodeMenu.js
+++ b/front-end/src/components/NodeMenu.js
@@ -19,7 +19,8 @@ export default function NodeMenu(props) {
                             const config = data.options;
                             delete data.options;
                             return (
-                                <NodeMenuItem key={data.node_key} nodeInfo={data} config={config} />
+                                <NodeMenuItem key={data.node_key || data.filename}
+                                              nodeInfo={data} config={config} />
                             )}
                         )}
                     </ul>
@@ -32,16 +33,23 @@ export default function NodeMenu(props) {
 
 
 function NodeMenuItem(props) {
+    if (!props.nodeInfo.missing_packages) {
+        return (
+                <li className="NodeMenuItem"
+                    draggable={true}
+                    onDragStart={event => {
+                        event.dataTransfer.setData(
+                            'storm-diagram-node',
+                            JSON.stringify(props));
+                    }}
+                    style={{color: props.nodeInfo.color}}>
+                    {props.nodeInfo.name}
+                </li>
+    } else {
+        return (
+                <li className="NodeMenuItem invalid">{props.nodeInfo.filename}</li>
+        )
+    }
     return (
-        <li className="NodeMenuItem"
-            draggable={true}
-            onDragStart={event => {
-                event.dataTransfer.setData(
-                    'storm-diagram-node',
-                    JSON.stringify(props));
-            }}
-            style={{ color: props.nodeInfo.color }}>
-            {props.nodeInfo.name}
-        </li>
     )
 }

--- a/front-end/src/components/NodeMenu.js
+++ b/front-end/src/components/NodeMenu.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as _ from 'lodash';
-import { Col } from 'react-bootstrap';
+import { Col, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import CustomNodeUpload from "./CustomNodeUpload";
 
 
@@ -34,7 +34,12 @@ export default function NodeMenu(props) {
 
 function NodeMenuItem(props) {
     if (!props.nodeInfo.missing_packages) {
+        const tooltip = props.nodeInfo.doc || "This node has no documentation."
         return (
+            <OverlayTrigger
+                placement="right"
+                delay={{ show: 250, hide: 250 }}
+                overlay={<NodeTooltip message={tooltip} />}>
                 <li className="NodeMenuItem"
                     draggable={true}
                     onDragStart={event => {
@@ -45,11 +50,27 @@ function NodeMenuItem(props) {
                     style={{color: props.nodeInfo.color}}>
                     {props.nodeInfo.name}
                 </li>
+            </OverlayTrigger>
+        )
     } else {
+        let tooltip = "These Python modules could not be imported: ";
+        tooltip += props.nodeInfo.missing_packages.join(", ");
         return (
+            <OverlayTrigger
+                placement="right"
+                delay={{ show: 250, hide: 250 }}
+                overlay={<NodeTooltip message={tooltip} />}>
                 <li className="NodeMenuItem invalid">{props.nodeInfo.filename}</li>
+            </OverlayTrigger>
         )
     }
-    return (
-    )
 }
+
+
+// Overlay with props has to use ref forwarding
+const NodeTooltip = React.forwardRef((props, ref) => {
+    return (
+        <Tooltip {...props} ref={ref}>{props.message}</Tooltip>
+    )
+});
+

--- a/front-end/src/components/NodeMenu.js
+++ b/front-end/src/components/NodeMenu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as _ from 'lodash';
 import { Col } from 'react-bootstrap';
+import CustomNodeUpload from "./CustomNodeUpload";
 
 
 export default function NodeMenu(props) {
@@ -24,6 +25,7 @@ export default function NodeMenu(props) {
                     </ul>
                 </div>
             )}
+            <CustomNodeUpload onUpload={props.onUpload} />
         </Col>
     );
 }

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -22,6 +22,7 @@ class Workspace extends React.Component {
         this.engine.setModel(this.model);
         this.engine.setMaxNumberPointsPerLink(0);
         this.state = {nodes: []};
+        this.getAvailableNodes = this.getAvailableNodes.bind(this);
         this.load = this.load.bind(this);
         this.clear = this.clear.bind(this);
         this.handleNodeCreation = this.handleNodeCreation.bind(this);
@@ -29,10 +30,17 @@ class Workspace extends React.Component {
     }
 
     componentDidMount() {
+        this.getAvailableNodes();
+        API.initWorkflow(this.model).catch(err => console.log(err));
+    }
+
+    /**
+     * Retrieve available nodes from server to display in menu
+     */
+    getAvailableNodes() {
         API.getNodes()
             .then(nodes => this.setState({nodes: nodes}))
             .catch(err => console.log(err));
-        API.initWorkflow(this.model).catch(err => console.log(err));
     }
 
     /**

--- a/front-end/src/components/Workspace.js
+++ b/front-end/src/components/Workspace.js
@@ -115,7 +115,7 @@ class Workspace extends React.Component {
                     </Col>
                 </Row>
                 <Row className="Workspace">
-                    <NodeMenu nodes={this.state.nodes} />
+                    <NodeMenu nodes={this.state.nodes} onUpload={this.getAvailableNodes}/>
                     <Col xs={10}>
                         <div style={{position: 'relative', flexGrow: 1}}
                             onDrop={event => this.handleNodeCreation(event)}

--- a/front-end/src/styles/Workspace.css
+++ b/front-end/src/styles/Workspace.css
@@ -16,14 +16,22 @@
         linear-gradient(to bottom, rgba(54, 169, 231, 0.1) 1px, transparent 1px);
 }
 .NodeMenuItem {
-    cursor: pointer;
     background-color: white;
-    border-radius: 5px;
     margin-bottom: 3px;
+    box-shadow: 0px 2px 4px gray;
 }
-.NodeMenuItem::before {
+.NodeMenuItem[draggable] {
+    cursor: pointer;
+}
+.NodeMenuItem[draggable]::before {
     content: "+";
     padding-right: 10px;
     padding-left: 5px;
     color: black;
+}
+.NodeMenuItem.invalid::before {
+    content: "\26a0";
+    padding-right: 10px;
+    padding-left: 5px;
+    color: red;
 }


### PR DESCRIPTION
Matt was right about being able to reuse the FileUpload functionality, but the details were just different enough that it was easier to copy/paste/change into a new component than refactor well. So CustomNodeUpload is mostly duplicated code from FileUpload.

Upon successful upload, the app hits the endpoint for the list of available nodes to show the new one. This GIF shows the functionality, but it failed to capture the file dialog. So the random click in the middle of the screen is actually selecting the file.

![2020-04-25 17 31 24](https://user-images.githubusercontent.com/10101166/80311703-23ed4400-87af-11ea-9010-407ae662a7b0.gif)

Also in this PR are tooltips to show either the node docstring when hovering over a node menu item, or the missing packages error. I went with @reelmatt's suggestion in #71 and used a warning icon for these failed custom nodes.

![2020-04-25 19 03 02](https://user-images.githubusercontent.com/10101166/80311767-91997000-87af-11ea-84da-97bea3b62cc8.gif)

Also made some slight style changes to the node menu items to better match the wireframes, just let me know if we want to go back.
