### PR TITLE
Front-end bug fixes, GraphView tweaks

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -11563,6 +11563,14 @@
         }
       }
     },
+    "react-spinners-css": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-spinners-css/-/react-spinners-css-1.1.7.tgz",
+      "integrity": "sha512-wcnFtGXCgFbIDsPr9CDoDU+F01uojf+ot/jJi4DUfHJ9S/zVRE7lIfSbsSHtIeDltclr3Dq9rHnAUdYaOt4SIg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-test-renderer": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -22,6 +22,7 @@
     "react-bootstrap": "^1.0.0-beta.17",
     "react-dom": "^16.13.0",
     "react-scripts": "3.4.1",
+    "react-spinners-css": "^1.1.7",
     "react-window": "^1.8.5",
     "regenerator-runtime": "^0.13.5",
     "resize-observer-polyfill": "^1.5.1"

--- a/front-end/src/API.js
+++ b/front-end/src/API.js
@@ -144,9 +144,18 @@ export async function uploadWorkflow(formData) {
 async function handleEdge(link, method) {
     const sourceId = link.getSourcePort().getNode().options.id;
     const targetId = link.getTargetPort().getNode().options.id;
-    return fetchWrapper(
-        `/node/edge/${sourceId}/${targetId}`,
-        {method: method});
+
+    let endpoint;
+
+    if (link.getSourcePort().options.in) {
+        // If edge goes from IN port -> OUT port, reverse the ports
+        endpoint = `/node/edge/${targetId}/${sourceId}`;
+    } else {
+        // Otherwise, keep source -> target edge
+        endpoint = `/node/edge/${sourceId}/${targetId}`;
+    }
+
+    return fetchWrapper(endpoint, {method: method});
 }
 
 

--- a/front-end/src/components/CustomNode/CustomNodeWidget.js
+++ b/front-end/src/components/CustomNode/CustomNodeWidget.js
@@ -59,19 +59,29 @@ export default class CustomNodeWidget extends React.Component {
                 </PortWidget>
             );
         }
+
+        let graphView;
+        let width = 40;
+        if (this.props.node.options.node_type !== "flow_control") {
+            graphView = (
+                <div className="custom-node-tabular" onClick={this.toggleGraph}>
+                  <img src="tabular-icon.png" alt="Tabular" style={{width:25, height:25}}/>
+                </div>
+            );
+            width = 80;
+        }
+
         return (
             <div className="custom-node-wrapper">
                 <div className="custom-node-name">{this.props.node.options.name}</div>
-                <div className="custom-node" style={{ borderColor: this.props.node.options.color }}>
+                <div className="custom-node" style={{ borderColor: this.props.node.options.color, width: width }}>
                     <div className="custom-node-configure" onClick={this.toggleConfig}>{String.fromCharCode(this.icon)}</div>
                     <NodeConfig node={this.props.node}
                         show={this.state.showConfig}
                         toggleShow={this.toggleConfig}
                         onDelete={this.handleDelete}
                         onSubmit={this.acceptConfiguration} />
-                    <div className="custom-node-tabular"  onClick={this.toggleGraph}>
-                      <img src="tabular-icon.png" alt="Tabular" style={{width:25, height:25}}></img>
-                    </div>
+                    {graphView}
                     <GraphView node={this.props.node}
                         show={this.state.showGraph}
                         toggleShow={this.toggleGraph}

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -69,28 +69,15 @@ export default class GraphView extends React.Component {
     }
 
     Cell = ({ columnIndex, rowIndex, style }) => {
-      const className =  columnIndex % 2
-          ? rowIndex % 2 === 0
-            ? 'GridItemOdd'
-            : 'GridItemEven'
-          : rowIndex % 2
-            ? 'GridItemOdd'
-            : 'GridItemEven';
-
-      if (rowIndex === 0) {
-        return (
-          <div className={className} style={style}>
-            {this.state.keys[columnIndex]}
-          </div>
-        );
-      }
-
+      const className = (rowIndex % 2 === 0) ? 'GridItemEven' : 'GridItemOdd';
+      const column = this.state.columns[columnIndex];
+      
       return (
         <div className={className} style={style}>
-          {this.state.data[this.state.keys[columnIndex]][rowIndex.toString()] }
+          {(rowIndex === 0) ? column : this.state.data[column][rowIndex.toString()]}
         </div>
       );
-    }
+    };
 
 
     render() {

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -132,7 +132,7 @@ export default class GraphView extends React.Component {
                   height={displayHeight < 600 ? displayHeight + 5 : 600}
                   rowCount={this.state.rows.length}
                   rowHeight={index => 20}
-                  width={displayWidth < 800 ? displayWidth : 800}
+                  width={displayWidth < 900 ? displayWidth : 900}
               >
                 {this.Cell}
               </Grid>

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -130,7 +130,7 @@ export default class GraphView extends React.Component {
                   height={displayHeight < 600 ? displayHeight + 5 : 600}
                   rowCount={this.state.rows.length}
                   rowHeight={index => 20}
-                  width={displayWidth < 1000 ? displayWidth : 1000}
+                  width={displayWidth < 800 ? displayWidth : 800}
               >
                 {this.Cell}
               </Grid>
@@ -142,6 +142,7 @@ export default class GraphView extends React.Component {
               show={this.props.show}
               onHide={this.props.toggleShow}
               centered
+              dialogClassName={"GraphView"}
               onWheel={e => e.stopPropagation()}
           >
           <Modal.Header closeButton>

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -46,6 +46,7 @@ export default class GraphView extends React.Component {
     computeWidths = (columns, rowCount, data) => {
         const columnCount = columns.length;
         const widths = new Array(columnCount);
+        let maxWidth = this.state.maxWidth;
 
         for (let index = 0; index < columnCount; index++) {
             const column = columns[index];
@@ -58,10 +59,11 @@ export default class GraphView extends React.Component {
                 widths[index] = row.length;
               }
 
-              this.state.maxWidth += (widths[index] * 10);
+            maxWidth += widths[index] * 10;
             }
         }
 
+        this.setState({maxWidth: maxWidth});
         return widths;
     };
 

--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Roller } from 'react-spinners-css';
 import { Modal, Button } from 'react-bootstrap';
 import propTypes from 'prop-types';
 import { VariableSizeGrid as Grid } from 'react-window';
@@ -93,48 +94,57 @@ export default class GraphView extends React.Component {
 
 
     render() {
-      if (this.state.loading) {
-        return (<div>Loading data...</div>);
-      }
+      let body;
+      let footer;
 
-      if (this.state.columnCount < 1) {
-        return (
-          <Modal show={this.props.show} onHide={this.props.toggleShow} centered
-             onWheel={e => e.stopPropagation()}>
-          <Modal.Header>
-              <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-          Loading the data might take a while depending on how big the data is.
-          </Modal.Body>
-          <Modal.Footer>
-              <Button variant="secondary" onClick={this.onClose}>Cancel</Button>
-              <Button variant="secondary" onClick={this.load}>Load</Button>
-          </Modal.Footer>
-          </Modal>
-        );
+      if (this.state.loading) {
+          // Print loading message
+          body = (<Roller color="black" />);
+      } else if (this.state.columns.length < 1) {
+          // Print instructions about loading
+          body = "Loading the data might take a while depending on how big the data is.";
+          footer = (
+              <Modal.Footer>
+                <Button variant="secondary" onClick={this.onClose}>Cancel</Button>
+                <Button variant="secondary"
+                        disabled={this.props.node.options.status !== "complete"}
+                        onClick={this.load}>Load
+                </Button>
+              </Modal.Footer>
+          );
+      } else {
+          // Display the grid
+          body = (
+              <Grid
+                  ref={this.state.gridRef}
+                  className="Grid"
+                  columnCount={this.state.columns.length}
+                  columnWidth={index => this.columnWidths(index)}
+                  height={500}
+                  rowCount={this.state.rows.length}
+                  rowHeight={index => 20}
+                  width={800}
+              >
+                {this.Cell}
+              </Grid>
+          );
       }
 
       return (
-          <Modal show={this.props.show} onHide={this.props.toggleShow} centered
-              onWheel={e => e.stopPropagation()}>
+          <Modal
+              show={this.props.show}
+              onHide={this.props.toggleShow}
+              refreshData={this.props.refreshData}
+              centered
+              onWheel={e => e.stopPropagation()}
+          >
               <Modal.Header closeButton>
-                  <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
+                   <Modal.Title><b>{this.props.node.options.name}</b> View</Modal.Title>
               </Modal.Header>
               <Modal.Body>
-                  <Grid
-                      ref={this.state.gridRef}
-                      className="Grid"
-                      columnCount={this.state.columnCount}
-                      columnWidth={index => this.columnWidths(index)}
-                      height={150}
-                      rowCount={this.state.rowCount}
-                      rowHeight={index => 20}
-                      width={480}
-                    >
-                      {this.Cell}
-                    </Grid>
+                  {body}
               </Modal.Body>
+              {footer}
           </Modal>
       );
     }
@@ -145,4 +155,4 @@ GraphView.propTypes = {
     show: propTypes.bool,
     toggleShow: propTypes.func,
     onClose: propTypes.func,
-}
+};

--- a/front-end/src/styles/GraphView.css
+++ b/front-end/src/styles/GraphView.css
@@ -7,6 +7,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    border-right: 1px solid grey;
+    border-bottom: 1px solid grey;
 }
 
 .GridItemEven {

--- a/front-end/src/styles/GraphView.css
+++ b/front-end/src/styles/GraphView.css
@@ -1,6 +1,7 @@
 .Grid {
     border: 1px solid #d9dddd;
     width: auto;
+    margin: auto;
 }
 
 .GridItemEven, .GridItemOdd {
@@ -16,5 +17,5 @@
 }
 
 .GraphView {
-    max-width: 825px;
+    max-width: 925px;
 }

--- a/front-end/src/styles/GraphView.css
+++ b/front-end/src/styles/GraphView.css
@@ -15,6 +15,6 @@
     background-color: #f8f8f0;
 }
 
-.modal-dialog, .GraphView {
-    max-width: 70%;
+.GraphView {
+    max-width: 825px;
 }

--- a/front-end/src/styles/GraphView.css
+++ b/front-end/src/styles/GraphView.css
@@ -14,3 +14,7 @@
 .GridItemEven {
     background-color: #f8f8f0;
 }
+
+.modal-dialog, .GraphView {
+    max-width: 70%;
+}


### PR DESCRIPTION
**Fixes #59**: Updates the `Load` button in the `Modal.Footer` to be disabled if the Node has not been executed (i.e. `!= 'complete'`) and therefore no data available. The same status message appears whether there is data or not. For cases where there is a large file to load, a `react-spinners-css` Component now appears instead of the "Loading data..." message.

**Fixes #60**: Increased the `max-width` attribute for `.modal-dialog` which also affects the non-GraphView windows. This is great for the case where there is a large data file to display, but not great for smaller files/other Modal windows. I couldn't easily target a child of the `.modal-dialog` so I committed as-is.

Part of this fix also includes a clean-up of the `computeWidths` function to make the row/column names clearer. It also calculates the `maxWidth` of the Grid which allows to dynamically adjust the size for smaller data files. The default size has been bumped from 480x150 to 600x1000.

The grid style has also been tweaked slightly to shade every other row (and *not* alternate by columns) and adds a slight border on the edges.

**Fixes #74**: Adjusts the API call so that the NetworkX representation on the back will always store an edge from `outPort -> inPort` regardless of whether the user creates the edge in reverse.